### PR TITLE
Updated plaid client to use the v2.2 beta API internally, while keeping the external API the same.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,16 +45,10 @@ plaid.get(access_token, function(err, res) {
 ## Test
 To run the tests, you need to :
   - [Sign up](https://plaid.com/signup) for a key
-  - Set the user bank information into process variables
-The tests work only for a 'bofa' account so far.
-You'll have to provide the answer to a secret question during the tests to validate the connection to the bank.
+  - Set the clientid and secret into process variables
 ```
 export PLAID_CLIENTID=123456
 export PLAID_SECRET=7890
-export PLAID_USER_USERNAME=username
-export PLAID_USER_PASSWORD=pass
-export PLAID_USER_TYPE=bofa
-export PLAID_USER_EMAIL=test@plaid.com
 ```
 
 ```

--- a/lib/client.js
+++ b/lib/client.js
@@ -90,33 +90,35 @@ Client.prototype.connect = function (credentials, type, email, options, callback
 
   this._checkInitialized();
 
-  if (!credentials || typeof(credentials)!= 'object') {
-      throw new Error('[plaid]#connect: credentials must be an object');
-  }
-
   if(!callback && (typeof options ==='function')) {
     callback = options;
     options  = {};
   }
 
-  if(!type || typeof(type)!='string'){
-    throw new Error('[plaid]#connect: Type missing or invalid');
+  if (!credentials || typeof(credentials)!= 'object') {
+      throw new Error('[plaid]#connect: credentials must be an object');
   }
 
   if(!email || typeof(email)!='string'){
     throw new Error('[plaid]#connect: Email missing or invalid');
   }
 
+  if(!type || typeof(type)!='string'){
+    throw new Error('[plaid]#connect: Type missing or invalid');
+  }
+
   if(!callback){
     callback = function(){};
   }
 
-  this.options     = options;
-  this.credentials = credentials;
-  this.type        = type;
-  this.email       = email;
+  var params = {
+    credentials : JSON.stringify(credentials)
+    , email       : email
+    , type        : type
+    , options     : JSON.stringify(options)
+  };
 
-  return this._exec('submit', callback);
+  return this._exec('POST', 'connect', params, callback);
 };
 
 Client.prototype.step = function (access_token, mfa, options, callback) {
@@ -132,11 +134,17 @@ Client.prototype.step = function (access_token, mfa, options, callback) {
     callback = function(){};
   }
 
-  this.options      = options;
-  this.access_token = access_token;
-  this.mfa          = mfa;
+  if(!access_token || typeof(access_token)!='string'){
+    throw new Error('[plaid]#connect: Access token missing or invalid');
+  }
 
-  return this._exec('step', callback);
+  var params = {
+    access_token : access_token
+    , mfa          : mfa
+    , options      : JSON.stringify(options)
+  };
+
+  return this._exec('POST', 'step', params, callback);
 };
 
 Client.prototype.get = function(access_token, options, callback) {
@@ -147,11 +155,16 @@ Client.prototype.get = function(access_token, options, callback) {
     options = {};
   }
 
-  this.options = options;
+  if(!access_token || typeof(access_token)!='string'){
+    throw new Error('[plaid]#connect: Access token missing or invalid');
+  }
 
-  this.access_token = access_token;
+  var params = {
+    access_token : access_token
+    , options      : JSON.stringify(options)
+  };
 
-  return this._exec('get', callback);
+  return this._exec('GET', 'connect', params, callback);
 }
 
 Client.prototype.remove = function(access_token, options, callback) {
@@ -162,50 +175,66 @@ Client.prototype.remove = function(access_token, options, callback) {
     options = {};
   }
 
-  this.options = options;
+  if(!access_token || typeof(access_token)!='string'){
+    throw new Error('[plaid]#connect: Access token missing or invalid');
+  }
 
-  this.access_token = access_token;
+  var params = {
+    access_token : access_token
+  };
 
-  return this._exec('remove', callback);
+  return this._exec('DELETE', 'connect', params, callback);
 }
 
-Client.prototype._exec = function (method, callback){
+Client.prototype.get_entity = function(entity_id, options, callback) {
+  this._checkInitialized();
 
-  var uri = this.config.protocol + this.config.host + this.config.endpoint[method];
+  if(!callback && typeof(options) == 'function') {
+    callback = options;
+    options = {};
+  }
+
+  if(!entity_id || typeof(entity_id)!='string'){
+    throw new Error('[plaid]#connect: Entity ID missing or invalid');
+  }
+
+  var params = {
+    id : entity_id
+    , options   : JSON.stringify(options)
+  };
+
+  return this._exec('GET', 'entity', params, callback);
+}
+
+Client.prototype._exec = function (method, endpoint, params, callback){
+
+  var uri = this.config.protocol + this.config.host + this.config.endpoint[endpoint];
 
   var query = {
-      client_id   : this.client_id
-    , secret      : this.secret
-    , credentials : JSON.stringify(this.credentials)
-    , type        : this.type
-    , email       : this.email
-    , access_token: this.access_token
-    , options     : JSON.stringify(this.options)
-    , mfa         : this.mfa
+    client_id   : this.client_id,
+    secret      : this.secret
   }
 
-  // the login option has to be set a separate parameter
-  if (this.options.login) {
-    query.login = this.options.login;
+  for( var property in params ) {
+    query[property] = params[property];
   }
 
-  uri += "?"+qs.stringify(query);
-  
   var self = this;
 
   request(
-    { method: 'POST'
-    , uri: uri
-    //, qs : qs.stringify(query)
+    { method: method
+      , uri: uri
+      , form: query
     }
-  , function (error, response, body) {
+    , function (error, response, body) {
       if(!response) response = {};
-      if(error || response.statusCode != 200)
+      
+      if(error || response.statusCode < 200 || response.statusCode >= 300)
         return self._handleError(error, response.statusCode, body, callback);
-
+      
       self.body = body;
+
       return self._handleSuccess(callback);
-    
     }
   )
 }
@@ -217,55 +246,25 @@ Client.prototype._handleSuccess = function(callback){
     return callback("Couldn't parse body");
   }
 
-  if(this.body.status === 'MFA')
-    return this._handleMFA(callback);
-
-  if(!this.body.success && (typeof this.body.mfa === 'undefined')) 
-    return callback(this.body.error);
-
-  return callback(null, this.body, (this.body.mfa !== 'undefined'));
+  return callback(null, this.body, (typeof(this.body.mfa) !== 'undefined'));
 }
 
 Client.prototype._handleError = function(error, status, body, callback){
   if(error)
     return callback(error)
 
-  try{
+  try {
     body = JSON.parse(body);
-  }catch(err){
+  } catch(err) {
     return callback("Couldn't parse body");
   }
-
-  return callback(body.error || "Unknown error occured", body);
-}
-
-Client.prototype._handleMFA = function(callback){
-
-  this.config.endpoint  = '/connect/submit/step';
-  this.access_token     = this.access_token   || this.body.accessToken;
-  this.options.itemID   = this.options.itemID || this.body.message.itemID;
-
-  var self = this;
-  //helper
-  var step = function(credentials, callback){
-    if(self.options.mfaCL)
-      return self._mfaCL(credentials, callback);
-    return self.connect(credentials, self.type, self.email, self.options, callback);
-  }
-  var html = function(){
-    return self._formToHTML(self.body.message.form);
-  }
-  
-  this.body.message.step = step;
-  if(this.body.message.form)
-    this.body.message.form.html = html;
-  else
-    console.log(this.body.message);
-
-  return callback(null, this.body, true)
+	
+  return callback(body.message || "Unknown error occured", body);
 }
 
 /* MFA testing CL */
+
+// NOTE: what is this function used for? Can't find any tests for it.
 
 Client.prototype._mfaCL = function(credentials, callback){
   var readline = require('readline');

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -14,17 +14,16 @@ module.exports = {
    * Uses this host to send messages to
    * @type {String}
    */
-  host            : 'api-dev.plaid.io/v2',
-
+  host            : 'tartan.plaid.com',
+  
   /**
    * URL endpoints (including version)
    * @type {String}
    */
   endpoint : {
-    'get'    : '/connect/get',
-    'submit' : '/connect/submit',
-    'step'   : '/connect/step',
-    'remove' : '/connect/remove'
+    'connect' : '/connect',
+    'step'    : '/connect/step',
+    'entity'  : '/entity'
   }
-
+  
 };

--- a/test/utils.js
+++ b/test/utils.js
@@ -10,14 +10,4 @@ module.exports = {
 			, secret    : secret
 		};
 	},
-
-	getUser: function() {
-		return {
-				username : process.env.PLAID_USER_USERNAME
-			, password : process.env.PLAID_USER_PASSWORD
-			, type     : process.env.PLAID_USER_TYPE
-			, email    : process.env.PLAID_USER_EMAIL
-		};
-	},
-
 }


### PR DESCRIPTION
Client changes:
- Changed to use latest HTTP URL endpoints
- Using the correct HTTP method for each endpoint
- Setting only the correct query parameters for each endpoint
- Stopped lifting special 'login' parameter out of 'options' and into the main param list
- Switched to using form POST params instead of query string params, matching the docs
- Treating any 2xx response code as success, to support the 201 code returned for MFA
- Fixed broken check for presence of mfa field
- Removed unused '_handleMFA' function from client library
- Added a new function for 'get_entity'

Unit test changes:
- Stopped taking in username, password, type, and email from environment - now using the standard 'plaid_test', 'plaid_good', from the docs.
- Added a unit test for each of the 5 account types (amex, bofa, chase, citi, wells)
- Stopped asking for manual entry of MFA credential during unit tests. Unit tests should run to completion without user input.
- Added a unit test for locked accounts using 'plaid_locked' password.
- Updated existing tests to look for new messages.
