### PR TITLE
Updated Client.prototype._exec to support sending data through request body rather than URI

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -1,10 +1,10 @@
-var _         = require('underscore')
-  , async     = require('async')
-  , request   = require('request')
-  , qs        = require('querystring')
-  , defaults  = require('./defaults')
-  , forms     = require('forms')
-  , fields    = forms.fields;
+var _       = require('underscore'),
+  async     = require('async'),
+  request   = require('request'),
+  qs        = require('querystring'),
+  defaults  = require('./defaults'),
+  forms     = require('forms'),
+  fields    = forms.fields;
 
 /*
 TODO
@@ -23,8 +23,8 @@ Handle MFA
  * Plaid.io node client driver
  *
  * @param  {Object} config
- *   @param  {String} client_id     - Plaid.io "client_id" 
- *   @param  {String} secret        - Plaid.io "secret" 
+ *   @param  {String} client_id     - Plaid.io "client_id"
+ *   @param  {String} secret        - Plaid.io "secret"
  *
  */
 var Client = module.exports = function (config) {
@@ -38,8 +38,8 @@ var Client = module.exports = function (config) {
  * Initializes this client.
  *
  * @param  {Object} config
- *   @param  {String} client_id     - Plaid.io "client_id" 
- *   @param  {String} secret        - Plaid.io "secret" 
+ *   @param  {String} client_id     - Plaid.io "client_id"
+ *   @param  {String} secret        - Plaid.io "secret"
  *
  */
 Client.prototype.init = function (config) {
@@ -116,9 +116,9 @@ Client.prototype.connect = function (credentials, type, email, options, callback
   this.email       = email;
 
   // No access token or mfa for a connect.
-  if (this.access_token) 
+  if (this.access_token)
     this.access_token = null;
-  if (this.mfa) 
+  if (this.mfa)
     this.mfa = null;
 
   return this._exec('submit', callback);
@@ -157,7 +157,7 @@ Client.prototype.get = function(access_token, options, callback) {
   this.access_token = access_token;
 
   return this._exec('get', callback);
-}
+};
 
 Client.prototype.remove = function(access_token, options, callback) {
   this._checkInitialized();
@@ -172,65 +172,71 @@ Client.prototype.remove = function(access_token, options, callback) {
   this.access_token = access_token;
 
   return this._exec('remove', callback);
-}
+};
 
 Client.prototype._exec = function (method, callback){
 
   var uri = this.config.protocol + this.config.host + this.config.endpoint[method].route;
 
   var query = {
-      client_id   : this.client_id
-    , secret      : this.secret
-    , credentials : JSON.stringify(this.credentials)
-    , type        : this.type
-    , email       : this.email
-    , access_token: this.access_token
-    , options     : JSON.stringify(this.options)
-    , mfa         : this.mfa
-  }
+    client_id   : this.client_id,
+    secret      : this.secret,
+    credentials : this.credentials,
+    type        : this.type,
+    email       : this.email,
+    access_token: this.access_token,
+    options     : this.options,
+    mfa         : this.mfa
+  };
 
   // the login option has to be set a separate parameter
   if (this.options.login) {
     query.login = this.options.login;
   }
 
-  uri += "?"+qs.stringify(query);
-  
   var self = this;
-  
-  request(
-    { method: this.config.endpoint[method].method
-    , uri: uri
-    //, qs : qs.stringify(query)
-    }
-  , function (error, response, body) {
-      if(!response) response = {};
-      if(error || ( response.statusCode > 299 ) )
-        return self._handleError(error, response.statusCode, body, callback);
+  var requestOptions = {
+    method: this.config.endpoint[method].method
+  };
 
-      self.body = body;
-      return self._handleSuccess(callback);
-    
-    }
-  )
-}
+  // Set up the proper request options
+  if(requestOptions.method === "POST" || requestOptions.method === "PUT") {
+    requestOptions.uri = uri;
+    requestOptions.json = query;
+  } else {
+    requestOptions.uri = uri + "?" + qs.stringiy(query);
+  }
+
+  // Make the request
+  request(requestOptions, function (error, response, body) {
+    if(!response) response = {};
+    if(error || ( response.statusCode > 299 ) )
+      return self._handleError(error, response.statusCode, body, callback);
+
+    self.body = body;
+    return self._handleSuccess(callback);
+  });
+
+};
 
 Client.prototype._handleSuccess = function(callback){
-  try{
-    this.body = JSON.parse(this.body);
-  }catch(err){
-    return callback("Couldn't parse body");
+  if(typeof this.body === "string") {
+    try{
+      this.body = JSON.parse(this.body);
+    }catch(err){
+      return callback("Couldn't parse body");
+    }
   }
 
   if(this.body.status === 'MFA')
     return this._handleMFA(callback);
-  
+
   return callback(null, this.body, (typeof this.body.mfa !== 'undefined'));
-}
+};
 
 Client.prototype._handleError = function(error, status, body, callback){
   if(error)
-    return callback(error)
+    return callback(error);
 
   try{
     body = JSON.parse(body);
@@ -239,7 +245,7 @@ Client.prototype._handleError = function(error, status, body, callback){
   }
 
   return callback(body);
-}
+};
 
 Client.prototype._handleMFA = function(callback){
 
@@ -253,19 +259,19 @@ Client.prototype._handleMFA = function(callback){
     if(self.options.mfaCL)
       return self._mfaCL(credentials, callback);
     return self.connect(credentials, self.type, self.email, self.options, callback);
-  }
+  };
   var html = function(){
     return self._formToHTML(self.body.message.form);
-  }
-  
+  };
+
   this.body.message.step = step;
   if(this.body.message.form)
     this.body.message.form.html = html;
   else
     console.log(this.body.message);
 
-  return callback(null, this.body, true)
-}
+  return callback(null, this.body, true);
+};
 
 /* MFA testing CL */
 
@@ -292,7 +298,7 @@ Client.prototype._mfaCL = function(credentials, callback){
       credentials[display]=answer;
       return cbk();
     });
-  }
+  };
 
   var self = this;
   async.forEachSeries(holder, read, function(err, result){
@@ -303,7 +309,7 @@ Client.prototype._mfaCL = function(credentials, callback){
 
     return self.connect(self.credentials, self.type, self.email, self.options, callback);
   });
-}
+};
 
 Client.prototype._formToHTML = function(raw){
   var form = {};
@@ -317,4 +323,4 @@ Client.prototype._formToHTML = function(raw){
 
   return '<form>'+form+'</form>';
 
-}
+};


### PR DESCRIPTION
To address issue #8
- Changed Client.prototype._exec to send data through the request body rather than the URI on POST and PUT requests
- Client.prototype._handleSuccess should now only attempt to parse JSON data returned if the response body variable was actually a string. (request returns a JSON object if you send one)

To address some of issue #7
- Some style changes (changed lines prefixed with ", " and added semicolons after variable declarations) 
