### PR TITLE
test: remove "should" dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,8 +37,7 @@
   ],
   "devDependencies": {
     "jshint": "2.4.x",
-    "mocha": "1.18.x",
-    "should": "3.1.x"
+    "mocha": "1.18.x"
   },
   "main": "index",
   "directories": {

--- a/test/client.js
+++ b/test/client.js
@@ -1,7 +1,6 @@
 /* global before, describe, it */
 var assert = require('assert');
 
-var should = require('should');
 var _ = require('underscore');
 
 var plaid = require('..');
@@ -45,8 +44,8 @@ describe('connect fail', function() {
 
     p.connect(fakeUserInfo, fakeUserInfo.type, fakeUserInfo.email,
               function(err) {
-      err.should.have.property('code', 1102);
-      err.should.have.property('message', 'secret or client_id invalid');
+      assert.strictEqual(err.code, 1102);
+      assert.strictEqual(err.message, 'secret or client_id invalid');
       done();
     });
 
@@ -59,8 +58,8 @@ describe('connect fail', function() {
 
     p.connect(fakeUserInfo, fakeUserInfo.type, fakeUserInfo.email,
               function(err) {
-      err.should.have.property('code', 1102);
-      err.should.have.property('message', 'secret or client_id invalid');
+      assert.strictEqual(err.code, 1102);
+      assert.strictEqual(err.message, 'secret or client_id invalid');
       done();
     });
 
@@ -73,8 +72,8 @@ describe('connect fail', function() {
 
     p.connect(fakeUserInfo, fakeUserInfo.type, fakeUserInfo.email,
               function(err) {
-      err.should.have.property('code', 1200);
-      err.should.have.property('message', 'invalid credentials');
+      assert.strictEqual(err.code, 1200);
+      assert.strictEqual(err.message, 'invalid credentials');
       done();
     });
 
@@ -103,15 +102,16 @@ describe('connect success (Bank Of America)', function() {
 
     p.connect(userInfo, type, userInfo.email, options,
               function(err, res, mfa) {
-      should.not.exist(err);
+      assert.strictEqual(err, null);
 
-      res.should.have.property('access_token');
+      assert.strictEqual(_.has(res, 'access_token'), true);
       userToken = res.access_token;
 
       assert.strictEqual(mfa, true);
-      res.should.have.property('type', 'questions');
-      res.should.have.property('mfa').with.lengthOf(1);
-      res.mfa[0].should.have.property('question');
+      assert.strictEqual(res.type, 'questions');
+      assert.strictEqual(repr(res.mfa), '[object Array]');
+      assert.strictEqual(res.mfa.length, 1);
+      assert.strictEqual(_.has(res.mfa[0], 'question'), true);
 
       /**
        * Answer the question.
@@ -119,11 +119,12 @@ describe('connect success (Bank Of America)', function() {
       var answer = userInfo.mfa_question;
 
       p.step(userToken, answer, options, function(err, res) {
-        should.not.exist(err);
+        assert.strictEqual(err, null);
 
-        res.should.have.property('access_token');
-        res.should.have.property('accounts');
-        res.should.have.property('transactions').with.lengthOf(0);
+        assert.strictEqual(_.has(res, 'access_token'), true);
+        assert.strictEqual(_.has(res, 'accounts'), true);
+        assert.strictEqual(repr(res.transactions), '[object Array]');
+        assert.strictEqual(res.transactions.length, 0);
         userToken = res.access_token;
 
         done();
@@ -136,9 +137,9 @@ describe('connect success (Bank Of America)', function() {
   it('successfully get a user transactions', function(done) {
 
     p.get(userToken, function(err, res) {
-      should.not.exist(err);
-      res.should.have.property('accounts');
-      res.should.have.property('transactions');
+      assert.strictEqual(err, null);
+      assert.strictEqual(_.has(res, 'accounts'), true);
+      assert.strictEqual(_.has(res, 'transactions'), true);
       done();
     });
 
@@ -147,8 +148,8 @@ describe('connect success (Bank Of America)', function() {
   it('successfully remove a user', function(done) {
 
     p.remove(userToken, function(err, res) {
-      should.not.exist(err);
-      res.should.have.property('message', 'Successfully removed from system');
+      assert.strictEqual(err, null);
+      assert.strictEqual(res.message, 'Successfully removed from system');
       done();
     });
 
@@ -177,14 +178,15 @@ describe('connect success (American Express)', function() {
 
     p.connect(userInfo, type, userInfo.email, options,
               function(err, res, mfa) {
-      should.not.exist(err);
+      assert.strictEqual(err, null);
 
-      res.should.have.property('access_token');
+      assert.strictEqual(_.has(res, 'access_token'), true);
       userToken = res.access_token;
 
       assert.strictEqual(mfa, false);
-      res.should.have.property('accounts');
-      res.should.have.property('transactions').with.lengthOf(0);
+      assert.strictEqual(_.has(res, 'accounts'), true);
+      assert.strictEqual(repr(res.transactions), '[object Array]');
+      assert.strictEqual(res.transactions.length, 0);
       done();
 
     });
@@ -194,9 +196,9 @@ describe('connect success (American Express)', function() {
   it('successfully get a user transactions', function(done) {
 
     p.get(userToken, function(err, res) {
-      should.not.exist(err);
-      res.should.have.property('accounts');
-      res.should.have.property('transactions');
+      assert.strictEqual(err, null);
+      assert.strictEqual(_.has(res, 'accounts'), true);
+      assert.strictEqual(_.has(res, 'transactions'), true);
       done();
     });
 
@@ -205,8 +207,8 @@ describe('connect success (American Express)', function() {
   it('successfully remove a user', function(done) {
 
     p.remove(userToken, function(err, res) {
-      should.not.exist(err);
-      res.should.have.property('message', 'Successfully removed from system');
+      assert.strictEqual(err, null);
+      assert.strictEqual(res.message, 'Successfully removed from system');
       done();
     });
 
@@ -235,14 +237,15 @@ describe('connect success (Citi)', function() {
 
     p.connect(userInfo, type, userInfo.email, options,
               function(err, res, mfa) {
-      should.not.exist(err);
+      assert.strictEqual(err, null);
 
-      res.should.have.property('access_token');
+      assert.strictEqual(_.has(res, 'access_token'), true);
       userToken = res.access_token;
 
       assert.strictEqual(mfa, false);
-      res.should.have.property('accounts');
-      res.should.have.property('transactions').with.lengthOf(0);
+      assert.strictEqual(_.has(res, 'accounts'), true);
+      assert.strictEqual(repr(res.transactions), '[object Array]');
+      assert.strictEqual(res.transactions.length, 0);
       done();
 
     });
@@ -252,9 +255,9 @@ describe('connect success (Citi)', function() {
   it('successfully get a user transactions', function(done) {
 
     p.get(userToken, function(err, res) {
-      should.not.exist(err);
-      res.should.have.property('accounts');
-      res.should.have.property('transactions');
+      assert.strictEqual(err, null);
+      assert.strictEqual(_.has(res, 'accounts'), true);
+      assert.strictEqual(_.has(res, 'transactions'), true);
       done();
     });
 
@@ -263,8 +266,8 @@ describe('connect success (Citi)', function() {
   it('successfully remove a user', function(done) {
 
     p.remove(userToken, function(err, res) {
-      should.not.exist(err);
-      res.should.have.property('message', 'Successfully removed from system');
+      assert.strictEqual(err, null);
+      assert.strictEqual(res.message, 'Successfully removed from system');
       done();
     });
 
@@ -293,14 +296,15 @@ describe('connect success (Wells Fargo)', function() {
 
     p.connect(userInfo, type, userInfo.email, options,
               function(err, res, mfa) {
-      should.not.exist(err);
+      assert.strictEqual(err, null);
 
-      res.should.have.property('access_token');
+      assert.strictEqual(_.has(res, 'access_token'), true);
       userToken = res.access_token;
 
       assert.strictEqual(mfa, false);
-      res.should.have.property('accounts');
-      res.should.have.property('transactions').with.lengthOf(0);
+      assert.strictEqual(_.has(res, 'accounts'), true);
+      assert.strictEqual(repr(res.transactions), '[object Array]');
+      assert.strictEqual(res.transactions.length, 0);
       done();
 
     });
@@ -310,9 +314,9 @@ describe('connect success (Wells Fargo)', function() {
   it('successfully get a user transactions', function(done) {
 
     p.get(userToken, function(err, res) {
-      should.not.exist(err);
-      res.should.have.property('accounts');
-      res.should.have.property('transactions');
+      assert.strictEqual(err, null);
+      assert.strictEqual(_.has(res, 'accounts'), true);
+      assert.strictEqual(_.has(res, 'transactions'), true);
       done();
     });
 
@@ -321,8 +325,8 @@ describe('connect success (Wells Fargo)', function() {
   it('successfully remove a user', function(done) {
 
     p.remove(userToken, function(err, res) {
-      should.not.exist(err);
-      res.should.have.property('message', 'Successfully removed from system');
+      assert.strictEqual(err, null);
+      assert.strictEqual(res.message, 'Successfully removed from system');
       done();
     });
 
@@ -351,16 +355,14 @@ describe('connect success (Chase)', function() {
 
     p.connect(userInfo, type, userInfo.email, options,
               function(err, res, mfa) {
-      should.not.exist(err);
+      assert.strictEqual(err, null);
 
-      res.should.have.property('access_token');
+      assert.strictEqual(_.has(res, 'access_token'), true);
       userToken = res.access_token;
 
       assert.strictEqual(mfa, true);
-      res.should.have.property('type', 'device');
-      res.should.have.property('mfa');
-      res.mfa.should.have.property('message');
-      res.mfa.message.should.containEql('Code sent to');
+      assert.strictEqual(res.type, 'device');
+      assert.strictEqual(res.mfa.message.indexOf('Code sent to'), 0);
 
       /**
        * Answer the question.
@@ -368,11 +370,12 @@ describe('connect success (Chase)', function() {
       var answer = userInfo.mfa_code;
 
       p.step(userToken, answer, options, function(err, res) {
-        should.not.exist(err);
+        assert.strictEqual(err, null);
 
-        res.should.have.property('access_token');
-        res.should.have.property('accounts');
-        res.should.have.property('transactions').with.lengthOf(0);
+        assert.strictEqual(_.has(res, 'access_token'), true);
+        assert.strictEqual(_.has(res, 'accounts'), true);
+        assert.strictEqual(repr(res.transactions), '[object Array]');
+        assert.strictEqual(res.transactions.length, 0);
         userToken = res.access_token;
 
         done();
@@ -385,9 +388,9 @@ describe('connect success (Chase)', function() {
   it('successfully get a user transactions', function(done) {
 
     p.get(userToken, function(err, res) {
-      should.not.exist(err);
-      res.should.have.property('accounts');
-      res.should.have.property('transactions');
+      assert.strictEqual(err, null);
+      assert.strictEqual(_.has(res, 'accounts'), true);
+      assert.strictEqual(_.has(res, 'transactions'), true);
       done();
     });
 
@@ -396,8 +399,8 @@ describe('connect success (Chase)', function() {
   it('successfully remove a user', function(done) {
 
     p.remove(userToken, function(err, res) {
-      should.not.exist(err);
-      res.should.have.property('message', 'Successfully removed from system');
+      assert.strictEqual(err, null);
+      assert.strictEqual(res.message, 'Successfully removed from system');
       done();
     });
 
@@ -424,19 +427,21 @@ describe('Clear global variables', function() {
     var options = {login: true};
 
     p.connect(userInfo, type, userInfo.email, options, function(err, res) {
-      should.not.exist(err);
+      assert.strictEqual(err, null);
       userToken = res.access_token;
 
       var answer = userInfo.mfa_question;
       p.step(userToken, answer, options, function(err, res) {
-        should.not.exist(err);
-        res.should.have.property('transactions').with.lengthOf(0);
+        assert.strictEqual(err, null);
+        assert.strictEqual(repr(res.transactions), '[object Array]');
+        assert.strictEqual(res.transactions.length, 0);
 
         type = 'amex';
         var info = _.pick(userInfo, 'username', 'password');
         p.connect(info, type, userInfo.email, options, function(err, res) {
-          should.not.exist(err);
-          res.should.have.property('transactions').with.lengthOf(0);
+          assert.strictEqual(err, null);
+          assert.strictEqual(repr(res.transactions), '[object Array]');
+          assert.strictEqual(res.transactions.length, 0);
           done();
         });
 
@@ -447,3 +452,9 @@ describe('Clear global variables', function() {
   });
 
 });
+
+
+// repr :: a -> String
+function repr(val) {
+  return Object.prototype.toString.call(val);
+}


### PR DESCRIPTION
The test suite is not a suitable place for clever code. With should it's sometimes difficult to know exactly what is being asserted. For example:

``` javascript
should.not.exist(err);
```

The following assertion is unambiguous:

``` javascript
assert.strictEqual(err, null);
```
