### PR TITLE
Bumping packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   ],
   "dependencies": {
     "underscore": "1.5.2",
-    "request": "~2.16.6",
+    "request": "~2.40.0",
     "async": "~0.2.6",
     "forms": "~0.9.1"
   },


### PR DESCRIPTION
request module is outdated and was throwing 0.8.x engine errors.
forms 0.1.4 has a deprecation warning, bumped to latest.

ran `npm test` and all tests are passing

it'd also be cool if the npm package maintainer can publish a new version
