### PR TITLE
Allow options.type on all methods

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -131,12 +131,6 @@ Client.prototype.step = function(access_token, mfa, options, callback) {
     callback = function() {};
   }
 
-  // Allow client to specify a type, because ALL sandbox requests require a type
-  if (options && options.type) {
-    this.type = options.type
-    delete options.type;
-  }
-
   this.options = options;
   this.access_token = access_token;
   this.mfa = mfa;
@@ -197,6 +191,12 @@ Client.prototype._exec = function(route, callback) {
 
   var uri = this.config.protocol + this.config.host + '/' +
             this.config.endpoint[route].route;
+
+  // Allow client to specify a type, because ALL sandbox requests require a type
+  if (this.options && this.options.type) {
+    this.type = this.options.type;
+    delete this.options.type;
+  }
 
   var body = {
     client_id: this.client_id,

--- a/lib/client.js
+++ b/lib/client.js
@@ -131,6 +131,12 @@ Client.prototype.step = function(access_token, mfa, options, callback) {
     callback = function() {};
   }
 
+  // Allow client to specify a type, because ALL sandbox requests require a type
+  if (options && options.type) {
+    this.type = options.type
+    delete options.type;
+  }
+
   this.options = options;
   this.access_token = access_token;
   this.mfa = mfa;


### PR DESCRIPTION
This is required for sandbox requests, and the client currently has no way to specify it.

From the [Plaid API docs](https://plaid.com/docs/?api-overview/#sandbox):
> Institution type is required for ALL sandbox requests in order to better replicate institution specific steps and responses.