### PR TITLE
Added public endpoint for searching institutions

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ plaid.getCategories(plaid_env, callback);
 
 plaid.getInstitution(institution_id, plaid_env, callback);
 plaid.getInstitutions(plaid_env, callback);
+plaid.searchInstitutions(search_term, product, institution_id, plaid_env, callback);
 ```
 
 `plaid_env` dictates which Plaid API environment you will access.  Values are:

--- a/index.js
+++ b/index.js
@@ -274,6 +274,20 @@ Plaid.getInstitutions = function(env, callback) {
   }, callback);
 };
 
+Plaid.searchInstitutions = function(searchTerm, product, id, env, callback) {
+  var uri = null;
+  if (id)
+    uri = env + '/institutions/search?id=' + id;
+  else
+    uri = env + '/institutions/search?q=' + searchTerm + '&p=' + product;
+
+  this._publicRequest({
+    uri: uri,
+    method: 'GET',
+    body: {},
+  }, callback);
+};
+
 function handleApiResponse(err, res, $body, includeMfaResponse, callback) {
   if (res != null) {
     $body = R.assoc('statusCode', res.statusCode, $body);

--- a/test/public.js
+++ b/test/public.js
@@ -107,3 +107,27 @@ describe('Plaid.getInstitutions', function() {
   });
 
 });
+
+describe('Plaid.searchInstitutions', function() {
+
+  it('returns long tail Plaid institutions with search term and product', function(done) {
+    Plaid.searchInstitutions('charles', 'connect', null, Plaid.environments.tartan, function(err, res) {
+      eq(err, null);
+
+      assert(R.is(Array, res));
+
+      done();
+    });
+  });
+
+  it('returns one institution if id is passed and ignores other params', function(done) {
+    Plaid.searchInstitutions('charles', 'connect', '15671', Plaid.environments.tartan, function(err, res) {
+      eq(err, null);
+
+      assert(R.is(Object, res));
+
+      done();
+    });
+  });
+
+});


### PR DESCRIPTION
:mag_right: :bank:

I didn't add longtail endpoint as I don't have the need to paginate them and they are still under special access. As feedback I wish the new endpoints would be little more consistent:

- `/longtail` uses POST while `/search` uses GET
- `/longtail` is authenticated while `/search` is public
- Why have `id` in search if there's already another endpoint for getting individual endpoints?
- I think there's something wrong with the search endpoint as `q=charles` return a whole bunch of Charles Schwab institutions but `schwab` return only one