### PR TITLE
Fix "ERROR: The request could not be satisfied"

### DIFF
--- a/index.js
+++ b/index.js
@@ -287,7 +287,6 @@ Plaid.getCategory = function(category_id, env, callback) {
   this._publicRequest({
     uri: env + '/categories/' + category_id,
     method: 'GET',
-    body: {},
   }, callback);
 };
 
@@ -295,7 +294,6 @@ Plaid.getCategories = function(env, callback) {
   this._publicRequest({
     uri: env + '/categories',
     method: 'GET',
-    body: {},
   }, callback);
 };
 
@@ -303,7 +301,6 @@ Plaid.getInstitution = function(institution_id, env, callback) {
   this._publicRequest({
     uri: env + '/institutions/' + institution_id,
     method: 'GET',
-    body: {},
   }, callback);
 };
 
@@ -311,7 +308,6 @@ Plaid.getInstitutions = function(env, callback) {
   this._publicRequest({
     uri: env + '/institutions',
     method: 'GET',
-    body: {},
   }, callback);
 };
 
@@ -324,7 +320,6 @@ Plaid.searchInstitutions = function(options, env, callback) {
   this._publicRequest({
     uri: env + '/institutions/search?' + qs,
     method: 'GET',
-    body: {},
   }, callback);
 };
 

--- a/index.js
+++ b/index.js
@@ -287,6 +287,7 @@ Plaid.getCategory = function(category_id, env, callback) {
   this._publicRequest({
     uri: env + '/categories/' + category_id,
     method: 'GET',
+    json:true
   }, callback);
 };
 
@@ -294,6 +295,7 @@ Plaid.getCategories = function(env, callback) {
   this._publicRequest({
     uri: env + '/categories',
     method: 'GET',
+    json:true
   }, callback);
 };
 
@@ -308,6 +310,7 @@ Plaid.getInstitutions = function(env, callback) {
   this._publicRequest({
     uri: env + '/institutions',
     method: 'GET',
+    json:true
   }, callback);
 };
 
@@ -320,6 +323,7 @@ Plaid.searchInstitutions = function(options, env, callback) {
   this._publicRequest({
     uri: env + '/institutions/search?' + qs,
     method: 'GET',
+    json:true
   }, callback);
 };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plaid",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "description": "A node.js client for the Plaid API",
   "keywords": [
     "plaid",


### PR DESCRIPTION
In version "request": "2.74.x" when you add an empty "body" not working GET requests due to  generating the header "content-length:2".

Empty object gives the Size 2 due to the fact that is converted to a string ("{}".length == 2).