### PR TITLE
Add support for new institutions all endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,9 @@ plaid.getInstitutions(plaid_env, callback);
 
 plaid.searchInstitutions({id: institutionId}, env, callback);
 plaid.searchInstitutions({product: plaidProduct, query: searchString}, env, callback);
+
+plaid.searchAllInstitutions({id: institutionId}, env, callback);
+plaid.searchAllInstitutions({product: plaidProduct, query: searchString}, env, callback);
 ```
 
 `plaid_env` dictates which Plaid API environment you will access.  Values are:
@@ -154,6 +157,9 @@ plaidClient.exchangeToken(public_token, callback);
 
 // getLongtailInstitutions(Object, Function)
 plaidClient.getLongtailInstitutions(optionsObject, callback);
+
+// getAllInstitutions(Object, Function)
+plaidClient.getAllInstitutions(optionsObject, callback);
 ```
 
 **All parameters except `options` are required.**

--- a/index.js
+++ b/index.js
@@ -287,6 +287,16 @@ Plaid.Client.prototype.getLongtailInstitutions = function(options, callback) {
   }, callback);
 };
 
+// simplified `/institutions/all` endpoint
+// Replaces the deprecated Longtail Institutions endpoint
+Plaid.Client.prototype.getAllInstitutions = function(options, callback) {
+  this._authenticatedRequest({
+    uri: this.env + '/institutions/all',
+    method: 'POST',
+    body: options,
+  }, callback);
+};
+
 // Public Routes
 
 Plaid.getCategory = function(category_id, env, callback) {

--- a/index.js
+++ b/index.js
@@ -339,6 +339,20 @@ Plaid.searchInstitutions = function(options, env, callback) {
   }, callback);
 };
 
+// simplified `/institutions/all` endpoint
+// Replaces the deprecated `/institutions/search` endpoint
+Plaid.searchAllInstitutions = function(options, env, callback) {
+  var qs = querystring.stringify(R.reject(R.isNil, {
+    id: options.id,
+    p: options.product,
+    q: options.query,
+  }));
+  this._publicRequest({
+    uri: env + '/institutions/all/search?' + qs,
+    method: 'GET',
+  }, callback);
+};
+
 function handleApiResponse(err, res, $body, includeMfaResponse, callback) {
   if (res != null) {
     $body = R.assoc('statusCode', res.statusCode, $body);

--- a/test/authenticated.js
+++ b/test/authenticated.js
@@ -1051,3 +1051,24 @@ describe('Plaid.Client - Longtail Institutions', function() {
   });
 
 });
+
+describe('Plaid.Client - All Institutions', function() {
+  var client =
+    new Plaid.Client('test_id', 'test_secret', Plaid.environments.tartan);
+
+  // The /institutions/all endpoint requires additional permissions
+  // to access. Accessing it with the sandbox client ID and secret returns
+  // an error, which we test here.
+  it('Plaid.Client.getAllInstitutions returns institutions',
+    function(done) {
+    client.getAllInstitutions({}, function(err, res) {
+      eq(err, null);
+
+      eq(R.type(res.results), 'Array');
+      eq(R.type(res.total_count), 'Number');
+
+      done();
+    });
+  });
+
+});

--- a/test/public.js
+++ b/test/public.js
@@ -138,3 +138,34 @@ describe('Plaid.searchInstitutions', function() {
   });
 
 });
+
+describe('Plaid.searchAllInstitutions', function() {
+
+  it('returns a single institution given an "id"', function(done) {
+    Plaid.searchAllInstitutions({
+      id: 'bofa',
+    }, Plaid.environments.tartan, function(err, res) {
+      eq(err, null);
+
+      eq(res.id, 'bofa');
+      eq(R.type(res), 'Object');
+
+      done();
+    });
+  });
+
+  it('returns a list of institutions given a "product" and "query"',
+    function(done) {
+    Plaid.searchAllInstitutions({
+      product: 'connect',
+      query: 'suntrust',
+    }, Plaid.environments.tartan, function(err, res) {
+      eq(err, null);
+
+      eq(R.type(res), 'Array');
+
+      done();
+    });
+  });
+
+});


### PR DESCRIPTION
This PR adds support for the new `/institutions/all` and `institutions/all/search` endpoints. 

We were told that as of January 4, 2017 the former `institutions/longtail` and `/institutions/search` endpoints would no longer be supported and we should use the new `/institutions/all` endpoint. We noticed the node module we heavily depend upon does not yet support these. This PR adds support for these endpoints. 

Please let me know if you have any requested changes. I attempted to do this as surgically as possible as to not introduce any inconsistencies. 

This PR addresses https://github.com/plaid/plaid-node/issues/88