### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ plaidClient.getRiskUser(access_token, options, callback);
 // patchRiskUser(String, Object, Object?, Function)
 plaidClient.patchRiskUser(access_token, credentials, options, callback);
 // deleteRiskUser(String, Object?, Function)
-plaidClient.deleteIncomeUser(access_token, options, callback);
+plaidClient.deleteRiskUser(access_token, options, callback);
 
 
 // getBalance(String, Function)


### PR DESCRIPTION
The README incorrectly states 'deleteIncomeUser', where the comment directly
above it has 'deleteRiskUser'. This patch fixes the statement to be consistent
and also match up to the rest of the statements in that block of examples.