### PR TITLE
[#97] Handle undefined body when there's a response without one

### DIFF
--- a/index.js
+++ b/index.js
@@ -354,7 +354,7 @@ Plaid.searchAllInstitutions = function(options, env, callback) {
 };
 
 function handleApiResponse(err, res, $body, includeMfaResponse, callback) {
-  if (res != null) {
+  if (res != null && typeof $body != "undefined") {
     $body = R.merge({
       statusCode: res.statusCode,
       request_id: res.headers['x-request-id'],

--- a/test/authenticated.js
+++ b/test/authenticated.js
@@ -112,7 +112,7 @@ describe('Plaid.Client - Auth', function() {
   // Mocked client simulates connection failures
   var mocked_plaid = proxyquire('../', {
     request: function(body, callback) {
-      callback(new Error('foobar'));
+      callback(new Error('foobar'), {status: 402, headers: {}});
     },
   });
   var mocked_client = new mocked_plaid.Client(


### PR DESCRIPTION
This is more for illustration purposes and not necessarily intended for merging. 

This resolves https://github.com/plaid/plaid-node/issues/97 in 1.2.x versions but I'm not sure where to make this change given the new 2.0.x version that includes a significant refactor of the tests and implementation. Any idea if this case will already be taken care of in 2.0.x?