### PR TITLE
Increase tests timeout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,4 +24,4 @@ setup:
 
 .PHONY: test
 test:
-	$(ISTANBUL) cover node_modules/.bin/_mocha -- --timeout 20000
+	$(ISTANBUL) cover node_modules/.bin/_mocha -- --timeout 40000


### PR DESCRIPTION
Doubling the timeout, because the tests sometimes fail due to response time being greater than the existing timeout.