### PR TITLE
Updating environments variable to lower case in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ For example:
 ```javascript
 const plaid = require('plaid');
 
-const plaidClient = new plaid.Client(CLIENT_ID, SECRET, PUBLIC_KEY, plaid.environments.SANDBOX);
+const plaidClient = new plaid.Client(CLIENT_ID, SECRET, PUBLIC_KEY, plaid.environments.sandbox);
 
 plaidClient.getInstitutions(1, 0).then(successResponse => {
   return successResponse.institutions;


### PR DESCRIPTION
One of the examples uses `plaid.environments.SANDBOX`, since that example was created I imagine the casing was changed, as it is now lowercase.  This pull request updates that example.