### PR TITLE
Downgrade @types/node to 9.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "request": "^2.74.0"
   },
   "devDependencies": {
+    "@types/node": "9.x",
     "@types/request": "0.0.36",
     "async": "2.1.x",
     "dotenv": "4.0.x",


### PR DESCRIPTION
Due to a bug in @types/node v10.0.0, building plaid-node currently fails. See https://github.com/DefinitelyTyped/DefinitelyTyped/issues/25342. This PR downgrades typings to an older version.