### PR TITLE
Fix incorrect TypeScript typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -507,11 +507,11 @@ declare module 'plaid' {
     getAllTransactions(accessToken: string,
                        startDate: Iso8601DateString,
                        endDate: Iso8601DateString,
-    ): Promise<Array<Account>>;
+    ): Promise<Array<Transaction>>;
     getAllTransactions(accessToken: string,
                        startDate: Iso8601DateString,
                        endDate: Iso8601DateString,
-                       cb: Callback<Array<Account>>,
+                       cb: Callback<Array<Transaction>>,
     ): void;
 
     getInstitutions(count: number,

--- a/index.d.ts
+++ b/index.d.ts
@@ -63,7 +63,7 @@ declare module 'plaid' {
   interface Category {
     type: string;
     hierarchy: Array<string>;
-    id: string;
+    category_id: string;
   }
 
   interface PlaidError {


### PR DESCRIPTION
- Category: `id` should be `category_id`
- getAllTransactions: returns `Array<Transaction>`, not `Array<Account>`

The first definition which returns a Promise will still be incorrect until #157 is merged.