### PR TITLE
getAllTransactions: add optional options

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,8 +114,8 @@ plaidClient.getCreditDetails(access_token, cb);
 // getTransactions(String, Date(YYYY-MM-DD), Date(YYYY-MM-DD), Object?, Function)
 plaidClient.getTransactions(access_token, start_date, end_date, options, cb);
 
-// getAllTransactions(String, Date(YYYY-MM-DD), Date(YYYY-MM-DD), Function)
-plaidClient.getAllTransactions(access_token, start_date, end_date, cb);
+// getAllTransactions(String, Date(YYYY-MM-DD), Date(YYYY-MM-DD), Object?, Function)
+plaidClient.getAllTransactions(access_token, start_date, end_date, options, cb);
 
 // createStripeToken(String, String, Function)
 plaidClient.createStripeToken(access_token, account_id, cb);

--- a/index.d.ts
+++ b/index.d.ts
@@ -25,7 +25,7 @@ declare module 'plaid' {
     offset?: number;
   }
 
-  interface TransactionsAllRequestOptions extends ItemRequestOptions {}
+  interface GetAllTransactionsRequestOptions extends ItemRequestOptions {}
 
   interface AssetReportUser {
     client_user_id?: string | null;
@@ -513,7 +513,7 @@ declare module 'plaid' {
     getAllTransactions(accessToken: string,
                        startDate: Iso8601DateString,
                        endDate: Iso8601DateString,
-                       options?: TransactionsAllRequestOptions,
+                       options?: GetAllTransactionsRequestOptions,
     ): Promise<Array<Transaction>>;
     getAllTransactions(accessToken: string,
                        startDate: Iso8601DateString,
@@ -523,7 +523,7 @@ declare module 'plaid' {
     getAllTransactions(accessToken: string,
                        startDate: Iso8601DateString,
                        endDate: Iso8601DateString,
-                       options: TransactionsAllRequestOptions,
+                       options: GetAllTransactionsRequestOptions,
                        cb: Callback<Array<Transaction>>,
     ): void;
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -507,14 +507,21 @@ declare module 'plaid' {
                     cb: Callback<TransactionsResponse>,
     ): void;
 
-    // getAllTransactions(String, Date, Date, Function)
+    // getAllTransactions(String, Date, Date, Object?, Function)
     getAllTransactions(accessToken: string,
                        startDate: Iso8601DateString,
                        endDate: Iso8601DateString,
+                       options?: ItemRequestOptions
     ): Promise<Array<Transaction>>;
     getAllTransactions(accessToken: string,
                        startDate: Iso8601DateString,
                        endDate: Iso8601DateString,
+                       cb: Callback<Array<Transaction>>,
+    ): void;
+    getAllTransactions(accessToken: string,
+                       startDate: Iso8601DateString,
+                       endDate: Iso8601DateString,
+                       options: ItemRequestOptions,
                        cb: Callback<Array<Transaction>>,
     ): void;
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -511,7 +511,7 @@ declare module 'plaid' {
     getAllTransactions(accessToken: string,
                        startDate: Iso8601DateString,
                        endDate: Iso8601DateString,
-                       options?: ItemRequestOptions
+                       options?: ItemRequestOptions,
     ): Promise<Array<Transaction>>;
     getAllTransactions(accessToken: string,
                        startDate: Iso8601DateString,

--- a/index.d.ts
+++ b/index.d.ts
@@ -25,6 +25,8 @@ declare module 'plaid' {
     offset?: number;
   }
 
+  interface TransactionsAllRequestOptions extends ItemRequestOptions {}
+
   interface AssetReportUser {
     client_user_id?: string | null;
     first_name?: string | null;
@@ -511,7 +513,7 @@ declare module 'plaid' {
     getAllTransactions(accessToken: string,
                        startDate: Iso8601DateString,
                        endDate: Iso8601DateString,
-                       options?: ItemRequestOptions,
+                       options?: TransactionsAllRequestOptions,
     ): Promise<Array<Transaction>>;
     getAllTransactions(accessToken: string,
                        startDate: Iso8601DateString,
@@ -521,7 +523,7 @@ declare module 'plaid' {
     getAllTransactions(accessToken: string,
                        startDate: Iso8601DateString,
                        endDate: Iso8601DateString,
-                       options: ItemRequestOptions,
+                       options: TransactionsAllRequestOptions,
                        cb: Callback<Array<Transaction>>,
     ): void;
 

--- a/lib/PlaidClient.js
+++ b/lib/PlaidClient.js
@@ -214,7 +214,13 @@ Client.prototype.getTransactions =
 
 // getAllTransactions(String, Date, Date, Object?, Function)
 Client.prototype.getAllTransactions =
-  function(access_token, start_date, end_date, cb) {
+  function(access_token, start_date, end_date, options, cb) {
+    // juggle arguments
+    if (typeof options === 'function') {
+      cb = options;
+      options = {};
+    }
+
     var self = this;
 
     return wrapPromise(P.coroutine(function*() {
@@ -224,10 +230,10 @@ Client.prototype.getAllTransactions =
           access_token,
           start_date,
           end_date,
-          {
+          R.merge(options, {
             count: 500, // largest allowed value
             offset: transactions.length,
-          }
+          })
         );
 
         transactions = R.concat(

--- a/lib/PlaidClient.js
+++ b/lib/PlaidClient.js
@@ -219,6 +219,8 @@ Client.prototype.getAllTransactions =
     if (typeof options === 'function') {
       cb = options;
       options = {};
+    } else {
+      options = R.defaultTo({}, options);
     }
 
     var self = this;


### PR DESCRIPTION
This allows you to optionally specify options to getAllTransactions. Since `count` and `offset` are handled for you in this method, the only real valid option is `account_ids`, thus I've used the more limited `ItemRequestOptions` def in the typescript definition.