### PR TITLE
Fix binary data in the response and add Promise type bindings for Assets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /npm-debug.log
 .env
 .vs/
+.idea/

--- a/index.d.ts
+++ b/index.d.ts
@@ -375,6 +375,10 @@ declare module 'plaid' {
     warnings: Array<Warning>;
   }
 
+  interface AssetReportGetPdfResponse extends BaseResponse {
+    buffer: Buffer;
+  }
+
   interface AuditCopyCreateResponse extends BaseResponse {
     audit_copy_token: string;
   }
@@ -493,26 +497,41 @@ declare module 'plaid' {
                       options: AssetReportCreateOptions,
                       cb: Callback<AssetReportCreateResponse>): void;
 
+    createAssetReport(access_tokens: Array<string>,
+                      days_requested: number,
+                      options: AssetReportCreateOptions): Promise<AssetReportCreateResponse>;
+
     // getAssetReport(String, Function)
     getAssetReport(asset_report_token: string,
                    cb: Callback<AssetReportGetResponse>): void;
 
+    getAssetReport(asset_report_token: string): Promise<AssetReportGetResponse>;
+
     // getAssetReportPdf(String, Function)
     getAssetReportPdf(asset_report_token: string,
-                      cb: Callback<Buffer>): void;
+                      cb: Callback<AssetReportGetPdfResponse>): void;
+
+    getAssetReportPdf(asset_report_token: string): Promise<AssetReportGetPdfResponse>;
 
     // createAuditCopy(String, String, Function)
     createAuditCopy(asset_report_token: string,
                     auditor_id: string,
                     cb: Callback<AuditCopyCreateResponse>): void;
 
+    createAuditCopy(asset_report_token: string,
+                    auditor_id: string): Promise<AuditCopyCreateResponse>;
+
     // removeAuditCopy(String, Function)
     removeAuditCopy(audit_copy_token: string,
                     cb: Callback<AuditCopyRemoveResponse>): void;
 
+    removeAuditCopy(audit_copy_token: string): Promise<AuditCopyRemoveResponse>;
+
     // removeAssetReport(String, Function)
     removeAssetReport(asset_report_token: string,
                       cb: Callback<AssetReportRemoveResponse>): void;
+
+    removeAssetReport(asset_report_token: string): Promise<AssetReportRemoveResponse>;
 
     // getTransactions(String, Date, Date, Object?, Function)
     getTransactions(accessToken: string,

--- a/lib/PlaidClient.js
+++ b/lib/PlaidClient.js
@@ -285,6 +285,7 @@ function(asset_report_token, cb) {
     body: {
       asset_report_token: asset_report_token,
     },
+    binary: true,
   }, cb);
 };
 

--- a/lib/PlaidClient.js
+++ b/lib/PlaidClient.js
@@ -261,9 +261,8 @@ Client.prototype.createAssetReport =
       body: {
         access_tokens: access_tokens,
         days_requested: days_requested,
-        options: options,
       },
-    }, cb);
+    }, options, cb);
   };
 
 // getAssetReport(String, Function)

--- a/lib/plaidRequest.js
+++ b/lib/plaidRequest.js
@@ -73,7 +73,8 @@ var plaidRequest = function(context, requestSpec, clientRequestOptions, cb) {
     method: method,
     json: requestJSON,
     headers: headers,
-    timeout: DEFAULT_TIMEOUT_IN_MILLIS
+    timeout: DEFAULT_TIMEOUT_IN_MILLIS,
+    encoding: requestSpec.binary ? null : 'utf8',
   }, clientRequestOptions);
 
   return wrapPromise(new Promise(function(resolve, reject) {

--- a/lib/plaidRequest.js
+++ b/lib/plaidRequest.js
@@ -28,6 +28,13 @@ var handleApiResponse = function(resolve, reject, err, res, $body, isMfa) {
 
   // success response (non mfa)
   } else if (res.statusCode === 200) {
+    // when Plaid-Request-Id exists we assume binary data are returned
+    if (res.headers['plaid-request-id']) {
+      return resolve({
+        request_id: res.headers['plaid-request-id'],
+        buffer: $body
+      });
+    }
     return resolve($body);
 
   // plaid error

--- a/lib/plaidRequest.js
+++ b/lib/plaidRequest.js
@@ -30,8 +30,8 @@ var handleApiResponse = function(resolve, reject, err, res, $body, isMfa) {
   } else if (res.statusCode === 200) {
     // extract request id from header for binary data,
     // i.e. mime type application/*
-    if (res.headers['plaid-request-id'] &&
-        res.headers['content-type'] &&
+    if (res.headers['plaid-request-id'] != null &&
+        res.headers['content-type'] != null &&
         res.headers['content-type'].indexOf('application') === 0) {
       return resolve({
         request_id: res.headers['plaid-request-id'],

--- a/lib/plaidRequest.js
+++ b/lib/plaidRequest.js
@@ -28,8 +28,11 @@ var handleApiResponse = function(resolve, reject, err, res, $body, isMfa) {
 
   // success response (non mfa)
   } else if (res.statusCode === 200) {
-    // when Plaid-Request-Id exists we assume binary data are returned
-    if (res.headers['plaid-request-id']) {
+    // extract request id from header for binary data,
+    // i.e. mime type application/*
+    if (res.headers['plaid-request-id'] &&
+        res.headers['content-type'] &&
+        res.headers['content-type'].indexOf('application') === 0) {
       return resolve({
         request_id: res.headers['plaid-request-id'],
         buffer: $body

--- a/test/PlaidClientTest.js
+++ b/test/PlaidClientTest.js
@@ -846,7 +846,7 @@ describe('plaid.Client', () => {
         async.waterfall([
           createAssetReport,
           (asset_report_token, cb) => {
-            getAssetReportWithRetries(asset_report_token, 20, cb);
+            getAssetReportWithRetries(asset_report_token, 60, cb);
           },
           getAssetReportPdf,
           createAuditCopy,


### PR DESCRIPTION
1. `index.d.ts` did not have `Promise` based signatures for Assets-related methods
2. ~~`getAssetReportPdf` was returning only `Buffer` and hence losing request id which is provided in `Plaid-Request-Id` HTTP header~~
2. `getAssetReportPdf` returned incorrect data (closes #168) and also losing request id in the process which was provided in `Plaid-Request-Id` HTTP header
3. I use Intellij so I modified `.gitignore` accordingly
4. The options were not sent in `createAssetReport` (closes #170 )