### PR TITLE
Added new assets endpoints

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -43,6 +43,8 @@ declare module 'plaid' {
     user?: AssetReportUser;
   }
 
+  type AssetReportRefreshOptions = AssetReportCreateOptions;
+
   // DATA TYPES //////////////////////////////////////////////////////////////
 
   interface AccountCommon {
@@ -370,6 +372,9 @@ declare module 'plaid' {
     asset_report_token: string;
   }
 
+  type AssetReportFilterResponse = AssetReportCreateResponse;
+  type AssetReportRefreshResponse = AssetReportCreateResponse;
+
   interface AssetReportGetResponse extends BaseResponse {
     report: AssetReport;
     warnings: Array<Warning>;
@@ -382,6 +387,8 @@ declare module 'plaid' {
   interface AuditCopyCreateResponse extends BaseResponse {
     audit_copy_token: string;
   }
+
+  type AuditCopyGetResponse = AssetReportGetResponse;
 
   interface AuditCopyRemoveResponse extends BaseResponse {
     removed: boolean;
@@ -495,7 +502,7 @@ declare module 'plaid' {
     // getCreditDetails(String, Function)
     getCreditDetails: AccessTokenFn<CreditDetailsResponse>;
 
-    // createAssetReport([String], Number, Object?, Function)
+    // createAssetReport([String], Number, Object, Function)
     createAssetReport(access_tokens: Array<string>,
                       days_requested: number,
                       options: AssetReportCreateOptions,
@@ -504,6 +511,24 @@ declare module 'plaid' {
     createAssetReport(access_tokens: Array<string>,
                       days_requested: number,
                       options: AssetReportCreateOptions): Promise<AssetReportCreateResponse>;
+
+    // filterAssetReport(String, [String], Function)
+    filterAssetReport(asset_report_token: string,
+                      account_ids_to_exclude: Array<string>,
+                      cb: Callback<AssetReportFilterResponse>): void;
+
+    filterAssetReport(asset_report_token: string,
+                      account_ids_to_exclude: Array<string>): Promise<AssetReportFilterResponse>;
+
+    // refreshAssetReport(String, Number, Object, Function)
+    refreshAssetReport(asset_report_token: string,
+                       days_requested: number,
+                       options: AssetReportRefreshOptions,
+                       cb: Callback<AssetReportRefreshResponse>): void;
+
+    refreshAssetReport(asset_report_token: string,
+                       days_requested: number,
+                       options: AssetReportRefreshOptions): Promise<AssetReportRefreshResponse>;
 
     // getAssetReport(String, Function)
     getAssetReport(asset_report_token: string,
@@ -524,6 +549,12 @@ declare module 'plaid' {
 
     createAuditCopy(asset_report_token: string,
                     auditor_id: string): Promise<AuditCopyCreateResponse>;
+
+    // getAuditCopy(String, Function)
+    getAuditCopy(audit_copy_token: string,
+                 cb: Callback<AuditCopyGetResponse>): void;
+
+    getAuditCopy(audit_copy_token: string): Promise<AuditCopyGetResponse>;
 
     // removeAuditCopy(String, Function)
     removeAuditCopy(audit_copy_token: string,

--- a/lib/PlaidClient.js
+++ b/lib/PlaidClient.js
@@ -253,7 +253,7 @@ Client.prototype.getAllTransactions =
 Client.prototype.getCreditDetails =
   requestWithAccessToken('/credit_details/get');
 
-// createAssetReport([String], Number, Object?, Function)
+// createAssetReport([String], Number, Object, Function)
 Client.prototype.createAssetReport =
   function(access_tokens, days_requested, options, cb) {
     return this._authenticatedRequest({
@@ -264,6 +264,31 @@ Client.prototype.createAssetReport =
       },
     }, options, cb);
   };
+
+// filterAssetReport(String, [String], Function)
+Client.prototype.filterAssetReport =
+  function(asset_report_token, account_ids_to_exclude, cb) {
+    return this._authenticatedRequest({
+      path: '/asset_report/filter',
+      body: {
+        asset_report_token: asset_report_token,
+        account_ids_to_exclude: account_ids_to_exclude,
+      },
+    }, cb);
+  };
+
+// refreshAssetReport(String, Number, Object, Function)
+Client.prototype.refreshAssetReport =
+  function(asset_report_token, days_requested, options, cb) {
+    return this._authenticatedRequest({
+      path: '/asset_report/refresh',
+      body: {
+        asset_report_token: asset_report_token,
+        days_requested: days_requested,
+      },
+    }, options, cb);
+  };
+
 
 // getAssetReport(String, Function)
 Client.prototype.getAssetReport =
@@ -299,6 +324,17 @@ function(asset_report_token, auditor_id, cb) {
     },
   }, cb);
 };
+
+// getAuditCopy(String, Function)
+Client.prototype.getAuditCopy =
+  function(audit_copy_token, cb) {
+    return this._authenticatedRequest({
+      path: '/asset_report/audit_copy/get',
+      body: {
+        audit_copy_token: audit_copy_token,
+      },
+    }, cb);
+  };
 
 // removeAuditCopy(String, Function)
 Client.prototype.removeAuditCopy =

--- a/test/PlaidClientTest.js
+++ b/test/PlaidClientTest.js
@@ -759,7 +759,7 @@ describe('plaid.Client', () => {
           email: 'hello@test.com',
         },
       };
-      var auditor_id = 'fannie_mae';
+      var auditor_id = CLIENT_ID;
 
       var createAssetReport = (cb) => {
         pCl.createAssetReport([testAccessToken], days_requested, options,
@@ -797,10 +797,32 @@ describe('plaid.Client', () => {
             expect(response).to.be.ok();
             expect(response.report).to.be.ok();
 
-            cb(null, asset_report_token);
+            cb(null, asset_report_token, response.report);
           }
         });
       };
+
+      var filterAssetReport = (asset_report_token, report, cb) => {
+        var account_ids_to_exclude = [report.items[0].accounts[0].account_id];
+
+        pCl.filterAssetReport(asset_report_token,
+                              account_ids_to_exclude,
+                              (err, response) => {
+          expect(err).to.be(null);
+          expect(response).to.be.ok();
+
+          cb(null, asset_report_token);
+        });
+      }
+
+      var refreshAssetReport = (asset_report_token, cb) => {
+        pCl.refreshAssetReport(asset_report_token, 60, {}, (err, response) => {
+          expect(err).to.be(null);
+          expect(response).to.be.ok();
+
+          cb(null, asset_report_token);
+        });
+      }
 
       var getAssetReportPdf = (asset_report_token, cb) => {
         pCl.getAssetReportPdf(asset_report_token, (err, response) => {
@@ -819,6 +841,15 @@ describe('plaid.Client', () => {
           expect(response.audit_copy_token).to.be.ok();
 
           cb(null, asset_report_token, response.audit_copy_token);
+        });
+      };
+
+      var getAuditCopy = (asset_report_token, audit_copy_token, cb) => {
+        pCl.getAuditCopy(audit_copy_token, (err, response) => {
+          expect(err).to.be(null);
+          expect(response).to.be.ok();
+
+          cb(null, asset_report_token, audit_copy_token);
         });
       };
 
@@ -848,8 +879,11 @@ describe('plaid.Client', () => {
           (asset_report_token, cb) => {
             getAssetReportWithRetries(asset_report_token, 60, cb);
           },
+          filterAssetReport,
+          refreshAssetReport,
           getAssetReportPdf,
           createAuditCopy,
+          getAuditCopy,
           removeAuditCopy,
           removeAssetReport,
         ], cb);


### PR DESCRIPTION
This PR adds support for the following new endpoints:
- /asset_report/audit_copy/get
- /asset_report/filter
- /asset_report/refresh

It also adds test coverage for each.