### PR TITLE
Add support for include_institution_data

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -123,6 +123,12 @@ declare module 'plaid' {
     url_forgotten_password: string | null;
   }
 
+  interface InstitutionWithInstitutionData extends Institution {
+    logo: string;
+    primary_color: string;
+    url: string;
+  }
+
   interface InstitutionWithContactData extends Institution {
     addresses: Array<{
       city: string;

--- a/lib/PlaidClient.js
+++ b/lib/PlaidClient.js
@@ -361,14 +361,14 @@ function(asset_report_token, cb) {
 
 // getInstitutions(Number, Number, Function);
 Client.prototype.getInstitutions =
-  function(count, offset, cb) {
+  function(count, offset, options, cb) {
     return this._authenticatedRequest({
       path: '/institutions/get',
       body: {
         count: count,
         offset: offset
       },
-    }, cb);
+    }, options, cb);
   };
 
 // getInstitutionById(String, Object?, Function);

--- a/test/PlaidClientTest.js
+++ b/test/PlaidClientTest.js
@@ -924,6 +924,17 @@ describe('plaid.Client', () => {
         });
       });
 
+      it('get with include_institution_data', cb => {
+        pCl.getInstitutions(10, 0, {include_institution_data: true},
+          (err, successResponse) => {
+          expect(err).to.be(null);
+          expect(successResponse).to.be.ok();
+          expect(successResponse.institutions).to.be.an(Array);
+
+          cb();
+        });
+      });
+
       it('getById', cb => {
         pCl.getInstitutionById(testConstants.INSTITUTION, {},
         (err, successResponse) => {
@@ -937,6 +948,18 @@ describe('plaid.Client', () => {
 
       it('getById (w/o options arg)', cb => {
         pCl.getInstitutionById(testConstants.INSTITUTION,
+        (err, successResponse) => {
+          expect(err).to.be(null);
+          expect(successResponse).to.be.ok();
+          expect(successResponse.institution).to.be.ok();
+
+          cb();
+        });
+      });
+
+      it('getById with include_institution_data', cb => {
+        pCl.getInstitutionById(testConstants.INSTITUTION,
+          {include_institution_data: true},
         (err, successResponse) => {
           expect(err).to.be(null);
           expect(successResponse).to.be.ok();
@@ -966,6 +989,19 @@ describe('plaid.Client', () => {
 
           cb();
         });
+      });
+
+      it('searches with options include_institution_data', cb => {
+        pCl.searchInstitutionsByName(testConstants.INSTITUTION, null, {
+          include_institution_data: true
+        },
+          (err, successResponse) => {
+            expect(err).to.be(null);
+            expect(successResponse).to.be.ok();
+            expect(successResponse.institutions).to.be.an(Array);
+
+            cb();
+          });
       });
     });
 


### PR DESCRIPTION
This flag is supported for the following endpoints:
/institutions/search
/institutions/get
/institutions/get_by_id