### PR TITLE
Update getAllTransactions with more detail

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -417,6 +417,14 @@ declare module 'plaid' {
     item: Item;
   }
 
+  // omitting extending the BaseResponse since there isn't a single request_id
+  interface TransactionsAllResponse {
+    accounts: Array<Account>;
+    item: Item;
+    total_transactions: number;
+    transactions: Array<Transaction>;
+  }
+
   interface AssetReportCreateResponse extends BaseResponse {
     asset_report_id: string;
     asset_report_token: string;
@@ -649,17 +657,17 @@ declare module 'plaid' {
                        startDate: Iso8601DateString,
                        endDate: Iso8601DateString,
                        options?: GetAllTransactionsRequestOptions,
-    ): Promise<Array<Transaction>>;
+    ): Promise<TransactionsAllResponse>;
     getAllTransactions(accessToken: string,
                        startDate: Iso8601DateString,
                        endDate: Iso8601DateString,
-                       cb: Callback<Array<Transaction>>,
+                       cb: Callback<TransactionsAllResponse>,
     ): void;
     getAllTransactions(accessToken: string,
                        startDate: Iso8601DateString,
                        endDate: Iso8601DateString,
                        options: GetAllTransactionsRequestOptions,
-                       cb: Callback<Array<Transaction>>,
+                       cb: Callback<TransactionsAllResponse>,
     ): void;
 
     getInstitutions(count: number,

--- a/lib/PlaidClient.js
+++ b/lib/PlaidClient.js
@@ -182,6 +182,8 @@ Client.prototype.getAllTransactions =
 
     return wrapPromise(P.coroutine(function*() {
       var transactions = [];
+      var transactionsCount = 0;
+      var response = [];
       while (true) {
         const transactionsResponse = yield self.getTransactions(
           access_token,
@@ -193,14 +195,22 @@ Client.prototype.getAllTransactions =
           })
         );
 
+        response.accounts = transactionsResponse.accounts;
+        response.item  = transactionsResponse.item;
+
         transactions = R.concat(
-          transactions, transactionsResponse.transactions);
-        if (transactions.length >= transactionsResponse.total_transactions) {
+          transactions, transactionsResponse.transactions
+        );
+        transactionsCount += transactionsResponse.transactions.length;
+        if (transactionsCount >= transactionsResponse.total_transactions) {
           break;
         }
       }
 
-      return transactions;
+      response.total_transactions = transactionsCount;
+      response.transactions = transactions;
+
+      return response;
     })(), cb, {no_spread: true});
   };
 

--- a/lib/PlaidClient.js
+++ b/lib/PlaidClient.js
@@ -183,7 +183,7 @@ Client.prototype.getAllTransactions =
     return wrapPromise(P.coroutine(function*() {
       var transactions = [];
       var transactionsCount = 0;
-      var response = [];
+      var response = {};
       while (true) {
         const transactionsResponse = yield self.getTransactions(
           access_token,

--- a/test/PlaidClientTest.js
+++ b/test/PlaidClientTest.js
@@ -408,7 +408,7 @@ describe('plaid.Client', () => {
           getAllTransactionsWithRetries(accessToken, now, now, 5,
           (err, transactions) => {
             expect(err).to.be(null);
-            expect(transactions).to.be.an(Array);
+            expect(transactions.transactions).to.be.an(Array);
 
             cb();
           });
@@ -418,7 +418,7 @@ describe('plaid.Client', () => {
           P.promisify(getAllTransactionsWithRetries)
           (accessToken, now, now, 5).then(
             transactions => {
-            expect(transactions).to.be.an(Array);
+            expect(transactions.transactions).to.be.an(Array);
 
             cb();
           }).catch(err => cb(err));

--- a/test/PlaidClientTest.js
+++ b/test/PlaidClientTest.js
@@ -466,7 +466,7 @@ describe('plaid.Client', () => {
           pCl.getAllTransactions(accessToken, now, now,
             (err, transactions) => {
               expect(err).to.be(null);
-              expect(transactions).to.eql(R.range(0, 200));
+              expect(transactions.transactions).to.eql(R.range(0, 200));
 
               pCl.getTransactions.restore();
               cb();
@@ -487,7 +487,7 @@ describe('plaid.Client', () => {
             });
 
           pCl.getAllTransactions(accessToken, now, now).then(transactions => {
-            expect(transactions).to.eql(R.range(0, 200));
+            expect(transactions.transactions).to.eql(R.range(0, 200));
 
             pCl.getTransactions.restore();
             cb();
@@ -518,7 +518,7 @@ describe('plaid.Client', () => {
           pCl.getAllTransactions(accessToken, now, now,
             (err, transactions) => {
               expect(err).to.be(null);
-              expect(transactions).to.eql(R.range(0, 1200));
+              expect(transactions.transactions).to.eql(R.range(0, 1200));
 
               pCl.getTransactions.restore();
               cb();
@@ -548,7 +548,7 @@ describe('plaid.Client', () => {
 
           getAllTransactionsWithRetries(accessToken, now, now).then(
             transactions => {
-            expect(transactions).to.eql(R.range(0, 1200));
+            expect(transactions.transactions).to.eql(R.range(0, 1200));
 
             pCl.getTransactions.restore();
             cb();


### PR DESCRIPTION
This PR creates a new interface, `TransactionsAllResponse`, this interface mimics `TransactionsResponse` but omits `status_code` and `request_id` as it is the result of potentially multiple requests.

`getAllTransactions` now returns the `accounts` and `item` objects, the `total_transactions` count, along with a `transactions` object that contains all available transactions for a given Item.
