### PR TITLE
change investment transaction `class` prop to `type`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -232,7 +232,7 @@ declare module 'plaid' {
     amount: number | null;
     price: number | null;
     fees: number | null;
-    class: string | null;
+    type: string | null;
     iso_currency_code: string | null;
     unofficial_currency_code: string | null;
   }


### PR DESCRIPTION
reached decision today that this better nomenclature cc @pbernasconi 

I don't think we need to change the version at all because we have yet to publish. Is that correct?