### PR TITLE
Fix sandboxItemFireWebhook

### DIFF
--- a/lib/PlaidClient.js
+++ b/lib/PlaidClient.js
@@ -421,7 +421,7 @@ function(access_token, webhook_code, cb) {
       access_token: access_token,
       webhook_code: webhook_code,
     },
-  }, cb, true);
+  }, {}, cb, true);
 };
 
 module.exports = Client;


### PR DESCRIPTION
Resolves the following crash
```
node_modules/plaid/lib/wrapPromise.js:25
          cb(null, args);
          ^
TypeError: cb is not a function
    at Immediate._onImmediate (/Users/tony/dev/src/github.com/alkafinance/backend/node_modules/plaid/lib/wrapPromise.js:25:11)
    at runCallback (timers.js:794:20)
    at tryOnImmediate (timers.js:752:5)
    at processImmediate [as _immediateCallback] (timers.js:729:5)
```