### PR TITLE
Fix for when there are no transactions within a date range

### DIFF
--- a/lib/PlaidClient.js
+++ b/lib/PlaidClient.js
@@ -209,9 +209,12 @@ Client.prototype.getAllTransactions =
         response.accounts = transactionsResponse.accounts;
         response.item  = transactionsResponse.item;
 
-        transactions = R.concat(
-          transactions, transactionsResponse.transactions);
-        transactionsCount += transactionsResponse.transactions.length;
+        if (transactionsResponse.transactions != null) {
+          transactions = R.concat(
+            transactions, transactionsResponse.transactions);
+          transactionsCount += transactionsResponse.transactions.length;
+        }
+
         if (transactionsCount >= transactionsResponse.total_transactions) {
           break;
         }


### PR DESCRIPTION
When searching over a date range where no transactions exist, the is returned in the response:

```
{
  ...
  "total_transactions": 0,
  "transactions": null,
}
```

This caused Ramda to return the exception `null is not an array`


```

R.concat([1], null)  // -> null is not an array

```

