### PR TITLE
Handles assets i18n response schema

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -330,23 +330,11 @@ declare module 'plaid' {
     category?: Array<string>;
     category_id?: string;
     date_transacted?: string;
-    location?: AssetTransactionLocation;
+    location?: TransactionLocation;
     name?: string;
     payment_meta?: TransactionPaymentMeta;
     pending_transaction_id?: string;
     transaction_type?: string;
-  }
-
-  // Different from "TransactionLocation", as it belongs with "Assets"
-  // which is only for US.
-  interface AssetTransactionLocation {
-    address: string | null;
-    city: string | null;
-    lat: number | null;
-    lon: number | null;
-    state: string | null;
-    store_number: string | null;
-    zip: string | null;
   }
 
   interface ACHNumbers {

--- a/index.d.ts
+++ b/index.d.ts
@@ -308,32 +308,7 @@ declare module 'plaid' {
     days_available: number;
     historical_balances: Array<HistoricalBalance>;
     transactions: Array<AssetReportTransaction>;
-    owners: Array<AssetsIdentity>;
-  }
-
-  // Different from "Identity", as it belongs with "Assets"
-  // which is only for US.
-  interface AssetsIdentity {
-    addresses: Array<AssetsAddress>;
-    emails: Array<Email>;
-    names: Array<string>;
-    phone_numbers: Array<PhoneNumber>;
-  }
-
-  // Different from "Address", as it belongs with "Assets"
-  // which is only for US.
-  interface AssetsAddress {
-    data: AssetsAddressData;
-    primary: boolean;
-  }
-
-  // Different from "AddressData", as it belongs with "Assets"
-  // which is only for US.
-  interface AssetsAddressData {
-    city: string;
-    state: string;
-    zip: string;
-    street: string;
+    owners: Array<Identity>;
   }
 
   interface HistoricalBalance {

--- a/test/PlaidClientTest.js
+++ b/test/PlaidClientTest.js
@@ -716,9 +716,10 @@ describe('plaid.Client', () => {
               for (const owner of account.owners) {
                 for (const addr of owner.addresses) {
                   expect(addr.data.city).to.be.ok();
-                  expect(addr.data.state).to.be.ok();
-                  expect(addr.data.zip).to.be.ok();
+                  expect(addr.data.region).to.be.ok();
+                  expect(addr.data.postal_code).to.be.ok();
                   expect(addr.data.street).to.be.ok();
+                  expect(addr.data.country).to.be.ok();
                 }
               }
             }


### PR DESCRIPTION
- Replaces `AssetsIdentity` interface with `Identity` interface for i18n
- Replaces `AssetsTransactionLocation` interface with `TransactionLocation`
- Updates assets tests to expect i18n schema