### PR TITLE
fix promise example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,13 +280,11 @@ app.use(bodyParser.json());
 app.post('/plaid_exchange', (req, res) => {
   var public_token = req.body.public_token;
 
-  plaidClient.exchangePublicToken(public_token).then(res => {
-    const access_token = res.access_token;
-
-    plaidClient.getAccounts(access_token).then(res => {
-      console.log(res.accounts);
-    });
-  }).catch(err => {
+  return plaidClient.exchangePublicToken(public_token)
+  .then(res => res.access_token)
+  .then(accessToken => plaidClient.getAccounts(accessToken))
+  .then(res => console.log(res.accounts))
+  .catch(err => {
     // Indicates a network or runtime error.
     if (!(err instanceof plaid.PlaidError)) {
       res.sendStatus(500);


### PR DESCRIPTION
The provided example has a bug in it related to error handling. It's also written in a callback syntax that doesn't take advantage of promise's ability to flatten a series of steps. [I've written a bit about this as it's a very common bug with promises](https://jdxcode.com/posts/2020-01-19-async-javascript-patterns-for-2020/#promises-running-in-series).

Here is the original code for reference:

```javascript
  plaidClient.exchangePublicToken(public_token).then(res => {
    const access_token = res.access_token;

    plaidClient.getAccounts(access_token).then(res => {
      console.log(res.accounts);
    });
  }).catch(err => {
    // Indicates a network or runtime error.
    if (!(err instanceof plaid.PlaidError)) {
      res.sendStatus(500);
      return;
    }
    // ...
```

The bug here are `plaidClient.getAccounts` is not handled if it errors. Only `plaidClient.exchangePublicToken` is. If we return the promises in the `.then()` method, we can cascade the promise chain and add a single `.catch()` at the end that will catch all the errors.

If `getAccounts()` were to error out in this case, by default node would display an unhandled rejection warning but the request would just hang. Here is a [repl](https://repl.it/repls/PlasticProfitableBackslash) showing the behavior.

Thanks for the great work though! I'm using this SDK to work on a little [CLI](https://github.com/jdxcode/benjamin) to view your bank info on the command line. Everything has worked solidly 👍