### PR TITLE
add missing automatically_verified to verification_status

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -73,6 +73,7 @@ declare module 'plaid' {
       | 'pending_automatic_verification'
       | 'pending_manual_verification'
       | 'manually_verified'
+      | 'automatically_verified'
       | null;
   }
 


### PR DESCRIPTION
the `verification_status` is set to `automatically_verified` on `AccountCommon`-type when calling `getAccounts()` but the corresponding type is not sufficient. see debugger-screenshot:

![automated-penny-deposits-response](https://user-images.githubusercontent.com/16902398/74584441-af3da280-4fd2-11ea-8411-d1ec191f24b8.png)
