### PR TITLE
Add OAuth support to /institutions endpoints

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -181,6 +181,7 @@ declare module 'plaid' {
     name: string;
     products: Array<string>;
     country_codes: Array<string>;
+    oauth: boolean;
   }
 
   interface InstitutionWithDisplayData extends Institution {


### PR DESCRIPTION
Adds a new `oauth` field to the institution schema returned by `/institutions/get`, `/institutions/get_by_id`, and `/institutions/search`. No changes are necessary to support the new `oauth` request option for `/institutions/get` and `/institutions/search`.