### PR TITLE
replace request (deprecated) with axios

### DIFF
--- a/lib/plaidRequest.js
+++ b/lib/plaidRequest.js
@@ -95,7 +95,11 @@ var plaidRequest = function(context, requestSpec, clientRequestOptions, cb) {
           requestSpec.includeMfaResponse);
       })
       .catch((error) => {
-        return rejectWithAPIError(reject, error.response);
+        if (error.response) {
+          return rejectWithAPIError(reject, error.response);
+        } else {
+          throw error;
+        }
       });
   }), cb);
 };

--- a/lib/plaidRequest.js
+++ b/lib/plaidRequest.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var R = require('ramda');
-var request = require('request');
+var axios = require('axios');
 var pjson = require('../package.json');
 
 var PlaidError = require('./PlaidError');
@@ -11,25 +11,34 @@ var wrapPromise = require('./wrapPromise');
 // Max timeout of ten minutes
 var DEFAULT_TIMEOUT_IN_MILLIS = 10 * 60 * 1000;
 
-var handleApiResponse = function(resolve, reject, err, res, $body, isMfa) {
+var rejectWithAPIError = function(reject, res) {
+  return reject(new PlaidError({
+    error_type: 'API_ERROR',
+    status_code: res.status,
+    error_code: 'INTERNAL_SERVER_ERROR',
+    error_message: String(res.data),
+    display_message: null,
+    request_id: null,
+  }));
+};
+
+var handleApiResponse = function(resolve, reject, res, isMfa) {
+  var $body = res.data;
+
   if (res != null && R.type($body) === 'Object') {
-    $body.status_code = res.statusCode;
+    $body.status_code = res.status;
   }
 
-  // network / usage errors
-  if (err != null) {
-    return reject(err);
-
   // success response (MFA)
-  } else if (isMfa && res.statusCode === 200) {
+  if (isMfa && res.status === 200) {
     return resolve([null, $body]);
 
   // mfa response (MFA)
-  } else if (isMfa && res.statusCode === 210) {
+  } else if (isMfa && res.status === 210) {
     return resolve([$body, null]);
 
   // success response (non mfa)
-  } else if (res.statusCode === 200) {
+  } else if (res.status === 200) {
     // extract request id from header for binary data,
     // i.e. mime type application/*
     if (res.headers['plaid-request-id'] != null &&
@@ -48,14 +57,7 @@ var handleApiResponse = function(resolve, reject, err, res, $body, isMfa) {
 
   // Unknown body type returned, return a standard API_ERROR
   } else {
-    return reject(new PlaidError({
-      error_type: 'API_ERROR',
-      status_code: res.statusCode,
-      error_code: 'INTERNAL_SERVER_ERROR',
-      error_message: String($body),
-      display_message: null,
-      request_id: null,
-    }));
+    return rejectWithAPIError(reject, res);
   }
 };
 
@@ -78,19 +80,23 @@ var plaidRequest = function(context, requestSpec, clientRequestOptions, cb) {
   // merge the default request options with the client specified options,
   // this allows for clients to supply extra options to the request function
   var requestOptions = R.merge({
-    uri: uri,
+    url: uri,
     method: method,
-    json: requestJSON,
+    data: requestJSON,
     headers: headers,
     timeout: DEFAULT_TIMEOUT_IN_MILLIS,
-    encoding: requestSpec.binary ? null : 'utf8',
+    responseType: requestSpec.binary ? 'arrayBuffer' : 'json'
   }, clientRequestOptions);
 
   return wrapPromise(new Promise(function(resolve, reject) {
-    request(requestOptions, function(err, res, body) {
-      handleApiResponse(resolve, reject, err, res, body,
-        requestSpec.includeMfaResponse);
-    });
+    axios(requestOptions)
+      .then((res) => {
+        handleApiResponse(resolve, reject, res,
+          requestSpec.includeMfaResponse);
+      })
+      .catch((error) => {
+        return rejectWithAPIError(reject, error.response);
+      });
   }), cb);
 };
 

--- a/lib/plaidRequest.js
+++ b/lib/plaidRequest.js
@@ -11,7 +11,14 @@ var wrapPromise = require('./wrapPromise');
 // Max timeout of ten minutes
 var DEFAULT_TIMEOUT_IN_MILLIS = 10 * 60 * 1000;
 
-var rejectWithAPIError = function(reject, res) {
+var rejectWithPlaidError = function(reject, res) {
+  // plaid error
+  if (R.type(res.data) === 'Object') {
+    res.data.status_code = res.status;
+    return reject(new PlaidError(res.data));
+  }
+
+  // Unknown body type returned, return a standard API_ERROR
   return reject(new PlaidError({
     error_type: 'API_ERROR',
     status_code: res.status,
@@ -51,13 +58,8 @@ var handleApiResponse = function(resolve, reject, res, isMfa) {
     }
     return resolve($body);
 
-  // plaid error
-  } else if (R.type($body) === 'Object') {
-    return reject(new PlaidError($body));
-
-  // Unknown body type returned, return a standard API_ERROR
   } else {
-    return rejectWithAPIError(reject, res);
+    return rejectWithPlaidError(reject, res);
   }
 };
 
@@ -96,7 +98,7 @@ var plaidRequest = function(context, requestSpec, clientRequestOptions, cb) {
       })
       .catch((error) => {
         if (error.response) {
-          return rejectWithAPIError(reject, error.response);
+          return rejectWithPlaidError(reject, error.response);
         } else {
           throw error;
         }

--- a/lib/plaidRequest.js
+++ b/lib/plaidRequest.js
@@ -100,7 +100,7 @@ var plaidRequest = function(context, requestSpec, clientRequestOptions, cb) {
         if (error.response) {
           return rejectWithPlaidError(reject, error.response);
         } else {
-          throw error;
+          return reject(error);
         }
       });
   }), cb);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "plaid",
-  "version": "4.9.0",
+  "version": "4.10.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "plaid",
-  "version": "4.5.0",
+  "version": "4.9.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -67,6 +67,8 @@
       "version": "5.5.2",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
       "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+      "dev": true,
+      "optional": true,
       "requires": {
         "co": "^4.6.0",
         "fast-deep-equal": "^1.0.0",
@@ -106,6 +108,8 @@
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
       "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+      "dev": true,
+      "optional": true,
       "requires": {
         "safer-buffer": "~2.1.0"
       }
@@ -113,7 +117,9 @@
     "assert-plus": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+      "dev": true,
+      "optional": true
     },
     "assertion-error": {
       "version": "1.1.0",
@@ -138,12 +144,24 @@
     "aws-sign2": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+      "dev": true,
+      "optional": true
     },
     "aws4": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.7.0.tgz",
-      "integrity": "sha512-32NDda82rhwD9/JBCCkB+MRYDp0oSvlo2IL6rQWA10PQi7tDUM3eqMSltXmY+Oyl/7N3P3qNtAlv7X0d9bI28w=="
+      "integrity": "sha512-32NDda82rhwD9/JBCCkB+MRYDp0oSvlo2IL6rQWA10PQi7tDUM3eqMSltXmY+Oyl/7N3P3qNtAlv7X0d9bI28w==",
+      "dev": true,
+      "optional": true
+    },
+    "axios": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
+      "integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
+      "requires": {
+        "follow-redirects": "1.5.10"
+      }
     },
     "babel-runtime": {
       "version": "6.26.0",
@@ -171,6 +189,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
       "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+      "dev": true,
       "optional": true,
       "requires": {
         "tweetnacl": "^0.14.3"
@@ -207,7 +226,9 @@
     "caseless": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+      "dev": true,
+      "optional": true
     },
     "chai": {
       "version": "3.5.0",
@@ -279,7 +300,9 @@
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
+      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+      "dev": true,
+      "optional": true
     },
     "colors": {
       "version": "1.0.3",
@@ -417,7 +440,8 @@
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
     },
     "cst": {
       "version": "0.4.10",
@@ -440,6 +464,8 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "dev": true,
+      "optional": true,
       "requires": {
         "assert-plus": "^1.0.0"
       }
@@ -558,6 +584,7 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
       "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+      "dev": true,
       "optional": true,
       "requires": {
         "jsbn": "~0.1.0",
@@ -629,7 +656,9 @@
     "extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "dev": true,
+      "optional": true
     },
     "extract-zip": {
       "version": "1.6.7",
@@ -647,7 +676,9 @@
     "extsprintf": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+      "dev": true,
+      "optional": true
     },
     "eyes": {
       "version": "0.1.8",
@@ -658,12 +689,16 @@
     "fast-deep-equal": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
-      "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
+      "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
+      "dev": true,
+      "optional": true
     },
     "fast-json-stable-stringify": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+      "dev": true,
+      "optional": true
     },
     "fast-levenshtein": {
       "version": "2.0.6",
@@ -681,15 +716,37 @@
         "pend": "~1.2.0"
       }
     },
+    "follow-redirects": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+      "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
+      "requires": {
+        "debug": "=3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
     "forever-agent": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+      "dev": true,
+      "optional": true
     },
     "form-data": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
       "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
+      "dev": true,
+      "optional": true,
       "requires": {
         "asynckit": "^0.4.0",
         "combined-stream": "1.0.6",
@@ -718,6 +775,8 @@
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "dev": true,
+      "optional": true,
       "requires": {
         "assert-plus": "^1.0.0"
       }
@@ -777,12 +836,16 @@
     "har-schema": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+      "dev": true,
+      "optional": true
     },
     "har-validator": {
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
       "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
+      "dev": true,
+      "optional": true,
       "requires": {
         "ajv": "^5.1.0",
         "har-schema": "^2.0.0"
@@ -843,6 +906,8 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+      "dev": true,
+      "optional": true,
       "requires": {
         "assert-plus": "^1.0.0",
         "jsprim": "^1.2.2",
@@ -887,7 +952,9 @@
     "is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "dev": true,
+      "optional": true
     },
     "is-utf8": {
       "version": "0.2.1",
@@ -910,7 +977,8 @@
     "isstream": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+      "dev": true
     },
     "istanbul": {
       "version": "0.4.5",
@@ -964,6 +1032,7 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+      "dev": true,
       "optional": true
     },
     "jscs": {
@@ -1080,17 +1149,22 @@
     "json-schema": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+      "dev": true,
+      "optional": true
     },
     "json-schema-traverse": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
+      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
+      "dev": true,
+      "optional": true
     },
     "json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+      "dev": true
     },
     "jsonfile": {
       "version": "2.4.0",
@@ -1116,6 +1190,8 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
       "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "dev": true,
+      "optional": true,
       "requires": {
         "assert-plus": "1.0.0",
         "extsprintf": "1.3.0",
@@ -1293,8 +1369,7 @@
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-      "dev": true
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "mute-stream": {
       "version": "0.0.7",
@@ -1414,7 +1489,9 @@
     "oauth-sign": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-      "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
+      "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
+      "dev": true,
+      "optional": true
     },
     "once": {
       "version": "1.4.0",
@@ -1488,7 +1565,9 @@
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+      "dev": true,
+      "optional": true
     },
     "phantom": {
       "version": "4.0.12",
@@ -1608,12 +1687,15 @@
     "punycode": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+      "dev": true,
+      "optional": true
     },
     "qs": {
       "version": "6.5.2",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+      "dev": true
     },
     "ramda": {
       "version": "0.23.0",
@@ -1651,6 +1733,8 @@
       "version": "2.87.0",
       "resolved": "https://registry.npmjs.org/request/-/request-2.87.0.tgz",
       "integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
+      "dev": true,
+      "optional": true,
       "requires": {
         "aws-sign2": "~0.7.0",
         "aws4": "^1.6.0",
@@ -1730,12 +1814,15 @@
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
     },
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "optional": true
     },
     "samsam": {
       "version": "1.3.0",
@@ -1846,6 +1933,8 @@
       "version": "1.14.2",
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.2.tgz",
       "integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
+      "dev": true,
+      "optional": true,
       "requires": {
         "asn1": "~0.2.3",
         "assert-plus": "^1.0.0",
@@ -1939,6 +2028,8 @@
       "version": "2.3.4",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
       "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
+      "dev": true,
+      "optional": true,
       "requires": {
         "punycode": "^1.4.1"
       }
@@ -1947,6 +2038,8 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "dev": true,
+      "optional": true,
       "requires": {
         "safe-buffer": "^5.0.1"
       }
@@ -1955,6 +2048,7 @@
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+      "dev": true,
       "optional": true
     },
     "type-check": {
@@ -2055,12 +2149,16 @@
     "uuid": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
+      "dev": true,
+      "optional": true
     },
     "verror": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "dev": true,
+      "optional": true,
       "requires": {
         "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -24,9 +24,9 @@
   "dependencies": {
     "@types/node": "9.x",
     "@types/request": "^2.48.2",
+    "axios": "^0.19.2",
     "bluebird": "^3.5.1",
-    "ramda": "0.23.x",
-    "request": "^2.74.0"
+    "ramda": "0.23.x"
   },
   "devDependencies": {
     "async": "2.1.x",

--- a/test/mocks/api-valid-json.nb
+++ b/test/mocks/api-valid-json.nb
@@ -1,0 +1,6 @@
+>> POST /institutions/get_by_id
+>> ={"public_key":"yyy","institution_id":"ins_1"}
+<< 200
+<< plaid-request-id: 1234abcd
+<< content-type: application/json; charset=utf-8
+<< ={"institution_id": "ins_1", "description": "more money, more problems"}

--- a/test/plaidRequest.js
+++ b/test/plaidRequest.js
@@ -12,23 +12,55 @@ const plaid = require('../');
 const plaidRequest = require('../lib/plaidRequest');
 
 const eq = assert.strictEqual;
+const deepEqual = assert.deepEqual;
 
 describe('plaid.plaidRequest', () => {
-  it('gracefully handles invalid JSON from the API', done => {
-      const scope = nock('https://sandbox.plaid.com');
-      nockingbird.load(scope, './test/mocks/api-invalid-json.nb');
+  const scope = nock('https://sandbox.plaid.com');
 
-      plaidRequest({
-        env: plaid.environments.sandbox,
-        public_key: 'xxx',
-      }, {
-        path: '/institutions/get_by_id',
-        body: {institution_id: 'ins_3'},
-      }, {}, (err, res) => {
-        eq(res, undefined);
-        eq(err.error_code, 'INTERNAL_SERVER_ERROR');
-        scope.done();
-        done();
-      });
+  it('gracefully handles invalid JSON from the API', done => {
+    nockingbird.load(scope, './test/mocks/api-invalid-json.nb');
+
+    plaidRequest({
+      env: plaid.environments.sandbox,
+      public_key: 'xxx',
+    }, {
+      path: '/institutions/get_by_id',
+      body: { institution_id: 'ins_3' },
+    }, {}, (err, res) => {
+      eq(res, undefined);
+      eq(err.error_code, 'INTERNAL_SERVER_ERROR');
+      scope.done();
+      done();
+    });
+  });
+
+  it('resolves with request_id and data on happy path (non-MFA)', done => {
+    nockingbird.load(scope, './test/mocks/api-valid-json.nb');
+
+    const expectedRes = {
+      request_id: '1234abcd',
+      buffer: {
+        // from response body
+        institution_id: 'ins_1',
+        description: 'more money, more problems',
+        // added by plaidRequest
+        status_code: 200
+      }
+    };
+
+    plaidRequest({
+      env: plaid.environments.sandbox,
+      public_key: 'yyy',
+    }, {
+      path: '/institutions/get_by_id',
+      body: { institution_id: 'ins_1' },
+    }, {}, (err, res) => {
+
+
+      deepEqual(res, expectedRes);
+      eq(err, null);
+      scope.done();
+      done();
+    });
   });
 });

--- a/test/plaidRequest.js
+++ b/test/plaidRequest.js
@@ -25,7 +25,7 @@ describe('plaid.plaidRequest', () => {
       public_key: 'xxx',
     }, {
       path: '/institutions/get_by_id',
-      body: { institution_id: 'ins_3' },
+      body: {institution_id: 'ins_3'},
     }, {}, (err, res) => {
       eq(res, undefined);
       eq(err.error_code, 'INTERNAL_SERVER_ERROR');
@@ -53,7 +53,7 @@ describe('plaid.plaidRequest', () => {
       public_key: 'yyy',
     }, {
       path: '/institutions/get_by_id',
-      body: { institution_id: 'ins_1' },
+      body: {institution_id: 'ins_1'},
     }, {}, (err, res) => {
 
 


### PR DESCRIPTION
Addresses issue #264

General thinking was to try to keep changes to a minimum, for a number of reasons:
- keep the changeset within scope of the issue, and easily parsable/reviewable
- limit likelihood of breaking changes given limited testing around the `plaidRequest` module
- minimise interference/collision with anything the plaid team is doing or planning to do

So no refactors where they could be avoided (best as separate PR).

Rationale for choosing axios:
- very widely used
- actively maintained & documented
- convenient API

A second test case has been added for `plaidRequest`, to ensure the success path hasn't been broken, although the integration tests all pass.