### PR TITLE
Ensure callback is called after setup occurs

### DIFF
--- a/test/PlaidClientTest.js
+++ b/test/PlaidClientTest.js
@@ -91,17 +91,22 @@ describe('plaid.Client', () => {
     let testAccessToken;
 
     before(cb => {
-      pCl.sandboxPublicTokenCreate(testConstants.INSTITUTION,
-                                   testConstants.PRODUCTS, {},
-                                   (err, successResponse) => {
-        expect(err).to.be(null);
-        pCl.exchangePublicToken(successResponse.public_token,
-                                (err, successResponse) => {
-          expect(err).to.be(null);
-          testAccessToken = successResponse.access_token;
-        });
-      });
-      cb();
+      async.waterfall([
+        cb => {
+            pCl.sandboxPublicTokenCreate(testConstants.INSTITUTION,
+                testConstants.PRODUCTS, {}, cb);
+        },
+        (successResponse, cb) => {
+          pCl.exchangePublicToken(successResponse.public_token,
+              (err, successResponse) => {
+                if (err != null) {
+                  return cb(err);
+                }
+                testAccessToken = successResponse.access_token;
+                cb();
+          });
+        },
+      ], cb);
     });
 
     describe('item', () => {


### PR DESCRIPTION
This setup works by accident - as the callback is called synchronously, the sandbox calls will not have completed. I assume this is working as the tests are executed in order, and other async tests will occur.

However, it will make debugging extremely hard as the errors will surface randomly.