### PR TITLE
Add options type and override to getInstitutionById

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -60,6 +60,11 @@ declare module 'plaid' {
     webhook?: string;
   }
 
+  interface GetInstitutionByIdOptions {
+    include_optional_metadata?: boolean;
+    include_status?: boolean;
+  }
+
   // DATA TYPES //////////////////////////////////////////////////////////////
 
   interface AccountCommon {
@@ -1143,17 +1148,21 @@ declare module 'plaid' {
       cb: Callback<GetInstitutionsResponse<Institution>>,
     ): void;
 
-    getInstitutionById<T extends Institution>(
+    getInstitutionById(
       institutionId: string,
-      options?: Object,
-    ): Promise<GetInstitutionByIdResponse<T>>;
+      options?: GetInstitutionByIdOptions,
+    ): Promise<GetInstitutionByIdResponse<Institution>>;
+    getInstitutionById(
+      institutionId: string,
+      options: {include_optional_metadata: true},
+    ): Promise<GetInstitutionByIdResponse<InstitutionWithInstitutionData>>;
     getInstitutionById(
       institutionId: string,
       cb: Callback<GetInstitutionByIdResponse<Institution>>,
     ): void;
     getInstitutionById(
       institutionId: string,
-      options: Object,
+      options: GetInstitutionByIdOptions,
       cb: Callback<GetInstitutionByIdResponse<Institution>>,
     ): void;
 


### PR DESCRIPTION
Define the type of the options accepted by getInstitutionById and add and override to return an institution with data.

See https://plaid.com/docs/#institutions-by-id