### PR TITLE
Add clientApp typing to ClientOptions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -708,6 +708,7 @@ declare module 'plaid' {
 
   interface ClientOptions extends AxiosRequestConfig {
     version?: '2019-05-29' | '2018-05-22' | '2017-03-08';
+    clientApp?: string;
   }
 
   type IdentityFieldBase =  {


### PR DESCRIPTION
Fix for [quickstart issue #111](https://github.com/plaid/quickstart/issues/111) - adds option string field `clientApp` to ClientOptions