### PR TITLE
Remove the public key

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ Instructions for contributing to [plaid-node][1]. A node.js client library for t
   cp .env.example .env
   ```
 
-2. Go to the [Plaid Dashboard](https://dashboard.plaid.com/) and copy and paste your `client_id`, `public_key`, and sandbox `secret`
+2. Go to the [Plaid Dashboard](https://dashboard.plaid.com/) and copy and paste your `client_id` and sandbox `secret`
    into `.env` using a text editor of your choice.
 
 3. Install the necessary dependencies.
@@ -24,14 +24,12 @@ Instructions for contributing to [plaid-node][1]. A node.js client library for t
 ```console
 $ SECRET=$PLAID_SECRET \
 CLIENT_ID=$PLAID_CLIENT_ID \
-PUBLIC_KEY=$PLAID_PUBLIC_KEY \
 make test
 
 # Running specific tests
 $ GREP='constructor|item|assets' \
 SECRET=$PLAID_SECRET \
 CLIENT_ID=$PLAID_CLIENT_ID \
-PUBLIC_KEY=$PLAID_PUBLIC_KEY \
 make test
 
 ```

--- a/README.md
+++ b/README.md
@@ -31,7 +31,6 @@ You can specify the Plaid API version you wish to use when initializing `plaid-n
 const plaidClient = new plaid.Client(
   process.env.PLAID_CLIENT_ID,
   process.env.PLAID_SECRET,
-  process.env.PUBLIC_KEY,
   plaid.environments.sandbox,
   {version: '2019-05-29'} // '2019-05-29' | '2018-05-22' | '2017-03-08'
 );
@@ -45,13 +44,13 @@ For information about what has changed between versions and how to update your i
 The module supports all Plaid API endpoints.  For complete information about the API, head
 to the [docs][2].
 
-All endpoints require a valid `client_id`, `secret`, and `public_key` to
+All endpoints require a valid `client_id` and `secret` to
 access and are accessible from a valid instance of a Plaid `Client`:
 
 ```javascript
 const plaid = require('plaid');
 
-const plaidClient = new plaid.Client(client_id, secret, public_key, plaid_env, {version: '2019-05-29'});
+const plaidClient = new plaid.Client(client_id, secret, plaid_env, {version: '2019-05-29'});
 ```
 
 The `plaid_env` parameter dictates which Plaid API environment you will access. Values are:
@@ -62,7 +61,7 @@ The `plaid_env` parameter dictates which Plaid API environment you will access. 
 The `options` parameter is optional and allows for clients to override the default options used to make requests. e.g.
 
 ```javascript
-const patientClient = new plaid.Client(client_id, secret, public_key, plaid_env, {
+const patientClient = new plaid.Client(client_id, secret, plaid_env, {
   timeout: 30 * 60 * 1000, // 30 minutes
   agent: 'Patient Agent'
 });
@@ -78,7 +77,7 @@ Once an instance of the client has been created you use the following methods:
 const plaid = require('plaid');
 
 // Initialize client
-const plaidClient = new plaid.Client(client_id, secret, public_key, plaid_env, {version: '2018-05-22'});
+const plaidClient = new plaid.Client(client_id, secret, plaid_env, {version: '2018-05-22'});
 
 // createPublicToken(String, Function)
 plaidClient.createPublicToken(access_token, cb);
@@ -267,7 +266,6 @@ const plaid = require('plaid');
 const plaidClient = new plaid.Client(
   process.env.PLAID_CLIENT_ID,
   process.env.PLAID_SECRET,
-  process.env.PUBLIC_KEY,
   plaid.environments.sandbox,
   {version: '2018-05-22'}
 );

--- a/README.md
+++ b/README.md
@@ -28,12 +28,14 @@ $ npm install plaid
 You can specify the Plaid API version you wish to use when initializing `plaid-node`. Releases prior to `2.6.x` do not support versioning.
 
 ```javascript
-const plaidClient = new plaid.Client(
-  process.env.PLAID_CLIENT_ID,
-  process.env.PLAID_SECRET,
-  plaid.environments.sandbox,
-  {version: '2019-05-29'} // '2019-05-29' | '2018-05-22' | '2017-03-08'
-);
+const plaidClient = new plaid.Client({
+  clientID: process.env.PLAID_CLIENT_ID,
+  secret: process.env.PLAID_SECRET,
+  env: plaid.environments.sandbox,
+  options: {
+    version: '2019-05-29', // '2019-05-29' | '2018-05-22' | '2017-03-08'
+  },
+});
 ```
 
 For information about what has changed between versions and how to update your integration, head to the [API upgrade guide][api-upgrades].
@@ -50,7 +52,11 @@ access and are accessible from a valid instance of a Plaid `Client`:
 ```javascript
 const plaid = require('plaid');
 
-const plaidClient = new plaid.Client(client_id, secret, plaid_env, {version: '2019-05-29'});
+const plaidClient = new plaid.Client({
+  clientID: client_id,
+  secret: secret,
+  env: plaid_env,
+});
 ```
 
 The `plaid_env` parameter dictates which Plaid API environment you will access. Values are:
@@ -58,12 +64,17 @@ The `plaid_env` parameter dictates which Plaid API environment you will access. 
 - `plaid.environments.development` - use for integration development and testing, creates `Item`s on https://development.plaid.com
 - `plaid.environments.sandbox` - quickly build out your integration with stateful test data, creates `Item`s on https://sandbox.plaid.com
 
-The `options` parameter is optional and allows for clients to override the default options used to make requests. e.g.
+The `options` field is optional and allows for clients to override the default options used to make requests. e.g.
 
 ```javascript
-const patientClient = new plaid.Client(client_id, secret, plaid_env, {
-  timeout: 30 * 60 * 1000, // 30 minutes
-  agent: 'Patient Agent'
+const patientClient = new plaid.Client({
+  clientID: client_id,
+  secret: secret,
+  env: plaid_env,
+  options: {
+    timeout: 30 * 60 * 1000, // 30 minutes
+    version: '2019-05-29',
+  }
 });
 ```
 
@@ -77,7 +88,14 @@ Once an instance of the client has been created you use the following methods:
 const plaid = require('plaid');
 
 // Initialize client
-const plaidClient = new plaid.Client(client_id, secret, plaid_env, {version: '2018-05-22'});
+const plaidClient = new plaid.Client({
+  clientID: client_id,
+  secret: secret,
+  env: plaid_env,
+  options: {
+    version: '2019-05-29',
+  },
+});
 
 // createPublicToken(String, Function)
 plaidClient.createPublicToken(access_token, cb);
@@ -263,12 +281,14 @@ const bodyParser = require('body-parser');
 const express = require('express');
 const plaid = require('plaid');
 
-const plaidClient = new plaid.Client(
-  process.env.PLAID_CLIENT_ID,
-  process.env.PLAID_SECRET,
-  plaid.environments.sandbox,
-  {version: '2018-05-22'}
-);
+const plaidClient = new plaid.Client({
+  clientID: process.env.PLAID_CLIENT_ID,
+  secret: process.env.PLAID_SECRET,
+  env: plaid.environments.sandbox,
+  options: {
+    version: '2018-05-22',
+  },
+});
 
 const app = express();
 const port = process.env.PORT || 3000;

--- a/index.d.ts
+++ b/index.d.ts
@@ -752,7 +752,6 @@ declare module 'plaid' {
     constructor(
       clientId: string,
       secret: string,
-      publicKey: string,
       env: string,
       options?: ClientOptions,
     );

--- a/index.d.ts
+++ b/index.d.ts
@@ -717,9 +717,17 @@ declare module 'plaid' {
 
   interface SandboxItemSetVerificationStatusResponse extends BaseResponse {}
 
-  interface ClientOptions extends AxiosRequestConfig {
+  interface ClientOptions {
     version?: '2019-05-29' | '2018-05-22' | '2017-03-08';
     clientApp?: string;
+    timeout?: number;
+  }
+
+  interface ClientConfigs extends AxiosRequestConfig {
+    clientID: string;
+    secret: string;
+    env: string,
+    options: ClientOptions,
   }
 
   type IdentityFieldBase =  {
@@ -749,12 +757,7 @@ declare module 'plaid' {
   }
 
   class Client {
-    constructor(
-      clientId: string,
-      secret: string,
-      env: string,
-      options?: ClientOptions,
-    );
+    constructor(configs: ClientConfigs);
 
     exchangePublicToken(publicToken: string): Promise<TokenResponse>;
     exchangePublicToken(

--- a/lib/PlaidClient.js
+++ b/lib/PlaidClient.js
@@ -25,6 +25,10 @@ function Client(client_id, secret, env, options) {
     throw new Error('Invalid Plaid environment');
   }
 
+  if (arguments.length > 4) {
+    throw new Error('Too many arguments to constructor');
+  }
+
   this.client_id = client_id;
   this.secret = secret;
   this.env = env;

--- a/lib/PlaidClient.js
+++ b/lib/PlaidClient.js
@@ -12,34 +12,40 @@ var helpers = require('./_helpers');
 const DEFAULT_VERSION = '2019-05-29';
 
 // Client(String, String, String, String, Object?)
-function Client(client_id, secret, env, options) {
-  if (R.isNil(client_id)) {
+function Client(configs) {
+  if (!R.is(Object, configs)) {
+    throw new Error('Unexpected parameter type. Refer to https://github.com/plaid/plaid-node for how to create a Plaid client.');
+  }
+
+  if (R.isNil(configs.clientID)) {
     throw new Error('Missing Plaid "client_id"');
   }
 
-  if (R.isNil(secret)) {
+  if (R.isNil(configs.secret)) {
     throw new Error('Missing Plaid "secret"');
   }
 
-  if (!R.any(R.equals(env), R.values(plaidEnvironments))) {
+  if (!R.any(R.equals(configs.env), R.values(plaidEnvironments))) {
     throw new Error('Invalid Plaid environment');
   }
 
-  if (arguments.length > 4) {
+  if (arguments.length > 1) {
     throw new Error('Too many arguments to constructor');
   }
 
-  this.client_id = client_id;
-  this.secret = secret;
-  this.env = env;
+  this.client_id = configs.clientID;
+  this.secret = configs.secret;
+  this.env = configs.env;
 
-  if (options == null) {
-    options = {};
+  if (configs.options == null) {
+    configs.options = {};
   }
-  if (options.version == null) {
-    options.version = DEFAULT_VERSION;
+
+  if (configs.options.version == null) {
+    configs.options.version = DEFAULT_VERSION;
   }
-  this.client_request_opts = options;
+
+  this.client_request_opts = configs.options;
 }
 
 // Private

--- a/lib/PlaidClient.js
+++ b/lib/PlaidClient.js
@@ -14,7 +14,9 @@ const DEFAULT_VERSION = '2019-05-29';
 // Client(String, String, String, String, Object?)
 function Client(configs) {
   if (!R.is(Object, configs)) {
-    throw new Error('Unexpected parameter type. Refer to https://github.com/plaid/plaid-node for how to create a Plaid client.');
+    throw new Error('Unexpected parameter type. ' +
+    'Refer to https://github.com/plaid/plaid-node ' +
+    'for how to create a Plaid client.');
   }
 
   if (R.isNil(configs.clientID)) {

--- a/lib/PlaidClient.js
+++ b/lib/PlaidClient.js
@@ -12,17 +12,13 @@ var helpers = require('./_helpers');
 const DEFAULT_VERSION = '2019-05-29';
 
 // Client(String, String, String, String, Object?)
-function Client(client_id, secret, public_key, env, options) {
+function Client(client_id, secret, env, options) {
   if (R.isNil(client_id)) {
     throw new Error('Missing Plaid "client_id"');
   }
 
   if (R.isNil(secret)) {
     throw new Error('Missing Plaid "secret"');
-  }
-
-  if (R.isNil(public_key)) {
-    throw new Error('Missing Plaid "public_key"');
   }
 
   if (!R.any(R.equals(env), R.values(plaidEnvironments))) {
@@ -32,7 +28,6 @@ function Client(client_id, secret, public_key, env, options) {
   this.client_id = client_id;
   this.secret = secret;
   this.env = env;
-  this.public_key = public_key;
 
   if (options == null) {
     options = {};
@@ -56,7 +51,7 @@ var requestWithAccessToken = function(path) {
 };
 
 Client.prototype._authenticatedRequest =
-  function _authenticatedRequest(requestSpec, options, cb, withPublicKey) {
+  function _authenticatedRequest(requestSpec, options, cb) {
     // juggle arguments
     if (typeof options === 'function') {
       cb = options;
@@ -65,13 +60,10 @@ Client.prototype._authenticatedRequest =
       requestSpec.body.options = options;
     }
 
-    var context = R.merge({env: this.env}, withPublicKey ? {
-      public_key: this.public_key,
-    } : {
+    var context = R.merge({env: this.env}, {
       client_id: this.client_id,
       secret: this.secret,
-    }
-    );
+    });
 
     return plaidRequest(context, requestSpec, this.client_request_opts, cb);
   };
@@ -514,7 +506,7 @@ Client.prototype.getInstitutionById =
       body: {
         institution_id: institution_id,
       }
-    }, options, cb, true);
+    }, options, cb);
   };
 
 // searchInstitutionsByName(String, [String], Object?, Function)
@@ -526,7 +518,7 @@ Client.prototype.searchInstitutionsByName =
        query: query,
        products: products,
      }
-   }, options, cb, true);
+   }, options, cb);
  };
 
 // getCategories(Function)
@@ -563,7 +555,7 @@ function(institution_id, initial_products, options, cb) {
       institution_id: institution_id,
       initial_products: initial_products,
     },
-  }, options, cb, true);
+  }, options, cb);
 };
 
 // sandboxItemFireWebhook(String, String, Function) - sandbox only

--- a/lib/plaidRequest.js
+++ b/lib/plaidRequest.js
@@ -90,6 +90,7 @@ var plaidRequest = function(context, requestSpec, clientRequestOptions, cb) {
     responseType: requestSpec.binary ? 'arrayBuffer' : 'json'
   }, clientRequestOptions);
 
+
   return wrapPromise(new Promise(function(resolve, reject) {
     axios(requestOptions)
       .then((res) => {

--- a/lib/plaidRequest.js
+++ b/lib/plaidRequest.js
@@ -90,7 +90,6 @@ var plaidRequest = function(context, requestSpec, clientRequestOptions, cb) {
     responseType: requestSpec.binary ? 'arrayBuffer' : 'json'
   }, clientRequestOptions);
 
-
   return wrapPromise(new Promise(function(resolve, reject) {
     axios(requestOptions)
       .then((res) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "plaid",
-  "version": "4.11.0",
+  "version": "5.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/test/PlaidClientTest.js
+++ b/test/PlaidClientTest.js
@@ -24,7 +24,7 @@ describe('plaid.Client', () => {
     options: {
       version: '2019-05-29',
     },
-  }
+  };
 
   let pCl;
   beforeEach(() => {
@@ -32,12 +32,20 @@ describe('plaid.Client', () => {
   });
 
   describe('constructor', () => {
+    it('throws for invalid parameter', ()  => {
+      expect(() => {
+        plaid.Client('client_id');
+      }).to.throwException(e => {
+        expect(e).to.be.ok();
+        expect(e.message).to.equal('Unexpected parameter type. Refer to https://github.com/plaid/plaid-node for how to create a Plaid client.');
+      });
+    });
+
     it('throws for missing client_id', () => {
       expect(() => {
-        plaid.Client({
-          ...configs,
+        plaid.Client(R.merge(configs, {
           clientID: null,
-        });
+        }));
       }).to.throwException(e => {
         expect(e).to.be.ok();
         expect(e.message).to.equal('Missing Plaid "client_id"');
@@ -46,10 +54,9 @@ describe('plaid.Client', () => {
 
     it('throws for missing secret', () => {
       expect(() => {
-        plaid.Client({
-          ...configs,
+        plaid.Client(R.merge(configs, {
           secret: null,
-        });
+        }));
       }).to.throwException(e => {
         expect(e).to.be.ok();
         expect(e.message).to.equal('Missing Plaid "secret"');
@@ -58,10 +65,9 @@ describe('plaid.Client', () => {
 
     it('throws for invalid environment', () => {
       expect(() => {
-        plaid.Client({
-          ...configs,
+        plaid.Client(R.merge(configs, {
           env: 'gingham',
-        });
+        }));
       }).to.throwException(e => {
         expect(e).to.be.ok();
         expect(e.message).to.equal('Invalid Plaid environment');
@@ -80,7 +86,9 @@ describe('plaid.Client', () => {
     it('succeeds with all arguments', () => {
       expect(() => {
         R.forEachObjIndexed(env => {
-          plaid.Client(configs);
+          plaid.Client(R.merge(configs, {
+            env: env,
+          }));
         }, plaid.environments);
       }).not.to.throwException();
     });
@@ -88,10 +96,10 @@ describe('plaid.Client', () => {
     it('succeeds without any options', () => {
       expect(() => {
         R.forEachObjIndexed(env => {
-          plaid.Client({
-            ...configs,
+          plaid.Client(R.merge(configs, {
             options: null,
-          });
+            env: env,
+          }));
         }, plaid.environments);
       }).not.to.throwException();
     });

--- a/test/PlaidClientTest.js
+++ b/test/PlaidClientTest.js
@@ -14,7 +14,7 @@ const plaid = require('../');
 const testConstants = require('./testConstants.js');
 
 dotenv.config();
-const {SECRET, PUBLIC_KEY, CLIENT_ID} = process.env;
+const {SECRET, CLIENT_ID} = process.env;
 
 describe('plaid.Client', () => {
 
@@ -23,7 +23,6 @@ describe('plaid.Client', () => {
     pCl = new plaid.Client(
       CLIENT_ID,
       SECRET,
-      PUBLIC_KEY,
       plaid.environments.sandbox,
       {version: '2019-05-29'}
     );
@@ -32,7 +31,7 @@ describe('plaid.Client', () => {
   describe('constructor', () => {
     it('throws for missing client_id', () => {
       expect(() => {
-        plaid.Client(null, SECRET, PUBLIC_KEY, plaid.environments.sandbox);
+        plaid.Client(null, SECRET, plaid.environments.sandbox);
       }).to.throwException(e => {
         expect(e).to.be.ok();
         expect(e.message).to.equal('Missing Plaid "client_id"');
@@ -41,25 +40,16 @@ describe('plaid.Client', () => {
 
     it('throws for missing secret', () => {
       expect(() => {
-        plaid.Client(CLIENT_ID, null, PUBLIC_KEY,  plaid.environments.sandbox);
+        plaid.Client(CLIENT_ID, null, plaid.environments.sandbox);
       }).to.throwException(e => {
         expect(e).to.be.ok();
         expect(e.message).to.equal('Missing Plaid "secret"');
       });
     });
 
-    it('throws for missing public_key', () => {
-      expect(() => {
-        plaid.Client(CLIENT_ID, SECRET, null, plaid.environments.sandbox);
-      }).to.throwException(e => {
-        expect(e).to.be.ok();
-        expect(e.message).to.equal('Missing Plaid "public_key"');
-      });
-    });
-
     it('throws for invalid environment', () => {
       expect(() => {
-        plaid.Client(CLIENT_ID, SECRET, PUBLIC_KEY, 'gingham');
+        plaid.Client(CLIENT_ID, SECRET, 'gingham');
       }).to.throwException(e => {
         expect(e).to.be.ok();
         expect(e.message).to.equal('Invalid Plaid environment');
@@ -69,7 +59,7 @@ describe('plaid.Client', () => {
     it('succeeds with all arguments', () => {
       expect(() => {
         R.forEachObjIndexed(env => {
-          plaid.Client(CLIENT_ID, SECRET, PUBLIC_KEY, env);
+          plaid.Client(CLIENT_ID, SECRET, env);
         }, plaid.environments);
       }).not.to.throwException();
     });

--- a/test/PlaidClientTest.js
+++ b/test/PlaidClientTest.js
@@ -56,6 +56,24 @@ describe('plaid.Client', () => {
       });
     });
 
+    it('throws for invalid environment if we are still using public_key', () => {
+      expect(() => {
+        plaid.Client(CLIENT_ID, SECRET, 'public_key', plaid.environments.sandbox);
+      }).to.throwException(e => {
+        expect(e).to.be.ok();
+        expect(e.message).to.equal('Invalid Plaid environment');
+      });
+    });
+
+    it('throws for too many arguments', () => {
+      expect(() => {
+        plaid.Client(CLIENT_ID, SECRET, plaid.environments.sandbox, {}, 'extra arg');
+      }).to.throwException(e => {
+        expect(e).to.be.ok();
+        expect(e.message).to.equal('Too many arguments to constructor');
+      });
+    });
+
     it('succeeds with all arguments', () => {
       expect(() => {
         R.forEachObjIndexed(env => {

--- a/test/PlaidClientTest.js
+++ b/test/PlaidClientTest.js
@@ -37,7 +37,11 @@ describe('plaid.Client', () => {
         plaid.Client('client_id');
       }).to.throwException(e => {
         expect(e).to.be.ok();
-        expect(e.message).to.equal('Unexpected parameter type. Refer to https://github.com/plaid/plaid-node for how to create a Plaid client.');
+        expect(e.message).to.equal(
+          'Unexpected parameter type. Refer to ' +
+          'https://github.com/plaid/plaid-node ' +
+          'for how to create a Plaid client.'
+        );
       });
     });
 

--- a/test/PlaidClientTest.js
+++ b/test/PlaidClientTest.js
@@ -56,9 +56,14 @@ describe('plaid.Client', () => {
       });
     });
 
-    it('throws for invalid environment if we are still using public_key', () => {
+    it('throws for invalid environment if still using public_key', () => {
       expect(() => {
-        plaid.Client(CLIENT_ID, SECRET, 'public_key', plaid.environments.sandbox);
+        plaid.Client(
+          CLIENT_ID,
+          SECRET,
+          'public_key',
+          plaid.environments.sandbox
+        );
       }).to.throwException(e => {
         expect(e).to.be.ok();
         expect(e.message).to.equal('Invalid Plaid environment');
@@ -67,7 +72,13 @@ describe('plaid.Client', () => {
 
     it('throws for too many arguments', () => {
       expect(() => {
-        plaid.Client(CLIENT_ID, SECRET, plaid.environments.sandbox, {}, 'extra arg');
+        plaid.Client(
+          CLIENT_ID,
+          SECRET,
+          plaid.environments.sandbox,
+          {},
+          'extra arg'
+        );
       }).to.throwException(e => {
         expect(e).to.be.ok();
         expect(e.message).to.equal('Too many arguments to constructor');

--- a/test/PlaidClientTest.js
+++ b/test/PlaidClientTest.js
@@ -17,21 +17,27 @@ dotenv.config();
 const {SECRET, CLIENT_ID} = process.env;
 
 describe('plaid.Client', () => {
+  const configs = {
+    clientID: CLIENT_ID,
+    secret: SECRET,
+    env: plaid.environments.sandbox,
+    options: {
+      version: '2019-05-29',
+    },
+  }
 
   let pCl;
   beforeEach(() => {
-    pCl = new plaid.Client(
-      CLIENT_ID,
-      SECRET,
-      plaid.environments.sandbox,
-      {version: '2019-05-29'}
-    );
+    pCl = new plaid.Client(configs);
   });
 
   describe('constructor', () => {
     it('throws for missing client_id', () => {
       expect(() => {
-        plaid.Client(null, SECRET, plaid.environments.sandbox);
+        plaid.Client({
+          ...configs,
+          clientID: null,
+        });
       }).to.throwException(e => {
         expect(e).to.be.ok();
         expect(e.message).to.equal('Missing Plaid "client_id"');
@@ -40,7 +46,10 @@ describe('plaid.Client', () => {
 
     it('throws for missing secret', () => {
       expect(() => {
-        plaid.Client(CLIENT_ID, null, plaid.environments.sandbox);
+        plaid.Client({
+          ...configs,
+          secret: null,
+        });
       }).to.throwException(e => {
         expect(e).to.be.ok();
         expect(e.message).to.equal('Missing Plaid "secret"');
@@ -49,21 +58,10 @@ describe('plaid.Client', () => {
 
     it('throws for invalid environment', () => {
       expect(() => {
-        plaid.Client(CLIENT_ID, SECRET, 'gingham');
-      }).to.throwException(e => {
-        expect(e).to.be.ok();
-        expect(e.message).to.equal('Invalid Plaid environment');
-      });
-    });
-
-    it('throws for invalid environment if still using public_key', () => {
-      expect(() => {
-        plaid.Client(
-          CLIENT_ID,
-          SECRET,
-          'public_key',
-          plaid.environments.sandbox
-        );
+        plaid.Client({
+          ...configs,
+          env: 'gingham',
+        });
       }).to.throwException(e => {
         expect(e).to.be.ok();
         expect(e.message).to.equal('Invalid Plaid environment');
@@ -72,13 +70,7 @@ describe('plaid.Client', () => {
 
     it('throws for too many arguments', () => {
       expect(() => {
-        plaid.Client(
-          CLIENT_ID,
-          SECRET,
-          plaid.environments.sandbox,
-          {},
-          'extra arg'
-        );
+        plaid.Client(configs, 'extra arg');
       }).to.throwException(e => {
         expect(e).to.be.ok();
         expect(e.message).to.equal('Too many arguments to constructor');
@@ -88,7 +80,18 @@ describe('plaid.Client', () => {
     it('succeeds with all arguments', () => {
       expect(() => {
         R.forEachObjIndexed(env => {
-          plaid.Client(CLIENT_ID, SECRET, env);
+          plaid.Client(configs);
+        }, plaid.environments);
+      }).not.to.throwException();
+    });
+
+    it('succeeds without any options', () => {
+      expect(() => {
+        R.forEachObjIndexed(env => {
+          plaid.Client({
+            ...configs,
+            options: null,
+          });
         }, plaid.environments);
       }).not.to.throwException();
     });

--- a/test/mocks/api-invalid-json.nb
+++ b/test/mocks/api-invalid-json.nb
@@ -1,5 +1,5 @@
 >> POST /institutions/get_by_id
->> ={"public_key":"xxx","institution_id":"ins_3"}
+>> ={"client_id":"xxx","secret":"yyy","institution_id":"ins_3"}
 << 400
 << content-type: application/json; charset=utf-8
 << =<html>invalidJsonIsTheWorst</html>

--- a/test/mocks/api-valid-json.nb
+++ b/test/mocks/api-valid-json.nb
@@ -1,5 +1,5 @@
 >> POST /institutions/get_by_id
->> ={"public_key":"yyy","institution_id":"ins_1"}
+>> ={"client_id":"www","secret":"vvv","institution_id":"ins_1"}
 << 200
 << plaid-request-id: 1234abcd
 << content-type: application/json; charset=utf-8

--- a/test/plaidRequest.js
+++ b/test/plaidRequest.js
@@ -22,7 +22,8 @@ describe('plaid.plaidRequest', () => {
 
     plaidRequest({
       env: plaid.environments.sandbox,
-      public_key: 'xxx',
+      client_id: 'xxx',
+      secret: 'yyy',
     }, {
       path: '/institutions/get_by_id',
       body: {institution_id: 'ins_3'},
@@ -50,7 +51,8 @@ describe('plaid.plaidRequest', () => {
 
     plaidRequest({
       env: plaid.environments.sandbox,
-      public_key: 'yyy',
+      client_id: 'www',
+      secret: 'vvv',
     }, {
       path: '/institutions/get_by_id',
       body: {institution_id: 'ins_1'},


### PR DESCRIPTION
Endpoints in this lib have been updated to accept client_id/secret instead of the public_key.

This PR also consolidates the parameters for the `plaid.Client` call into an object so that if we make changes to the parameter list at a later point, it will be much easier to manage. 