### PR TITLE
[BREAKING] Add BACS support for payment initiation

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -502,6 +502,11 @@ declare module 'plaid' {
     country: Iso3166Alpha2CountryString;
   }
 
+  interface PaymentRecipientBacs {
+    account: string,
+    sort_code: string;
+  }
+
   interface PaymentRecipient {
     recipient_id: string;
     name: string;
@@ -1039,7 +1044,8 @@ declare module 'plaid' {
 
     createPaymentRecipient(
       name: string,
-      iban: string,
+      iban: string | null,
+      bacs: PaymentRecipientBacs | null,
       address: PaymentRecipientAddress | null,
     ): Promise<PaymentRecipientCreateResponse>;
 

--- a/lib/PlaidClient.js
+++ b/lib/PlaidClient.js
@@ -422,15 +422,16 @@ function(asset_report_token, cb) {
   }, cb);
 };
 
-// createPaymentRecipient(String, String, Object, Function)
+// createPaymentRecipient(String, String, Object, Object, Function)
 Client.prototype.createPaymentRecipient =
-  function(name, iban, address, cb) {
+  function(name, iban, address, bacs, cb) {
     return this._authenticatedRequest({
       path: '/payment_initiation/recipient/create',
       body: {
         name: name,
-        iban: iban,
+        iban: iban != null ? iban : undefined,
         address: address,
+        bacs: bacs != null ? bacs : undefined,
       },
     }, cb);
   };

--- a/test/PlaidClientTest.js
+++ b/test/PlaidClientTest.js
@@ -1010,11 +1010,12 @@ describe('plaid.Client', () => {
         country: 'GB',
       };
 
-      const createPaymentRecipient = (cb) => {
+      const createPaymentRecipientWithIban = (cb) => {
         pCl.createPaymentRecipient(
           'John Doe',
           'GB33BUKB20201555555555',
           address,
+          null,
           (err, response) => {
             expect(err).to.be(null);
             expect(response).to.be.ok();
@@ -1025,7 +1026,26 @@ describe('plaid.Client', () => {
           });
       };
 
-      const getPaymentRecipient = (recipient_id, cb) => {
+      const createPaymentRecipientWithBacs = (cb) => {
+        pCl.createPaymentRecipient(
+          'John Doe',
+          null,
+          address,
+          {
+            account: '12345678',
+            sort_code: '01-02-03',
+          },
+          (err, response) => {
+            expect(err).to.be(null);
+            expect(response).to.be.ok();
+            expect(response.request_id).to.be.ok();
+            expect(response.recipient_id).to.be.ok();
+
+            cb(null, response.recipient_id);
+          });
+      };
+
+      const getPaymentRecipientWithIban = (recipient_id, cb) => {
         pCl.getPaymentRecipient(recipient_id,
           (err, response) => {
             expect(err).to.be(null);
@@ -1034,6 +1054,21 @@ describe('plaid.Client', () => {
             expect(response.recipient_id).to.be.ok();
             expect(response.name).to.be.ok();
             expect(response.iban).to.be.ok();
+            expect(response.address).to.be.ok();
+
+            cb(null, recipient_id);
+          });
+      };
+
+      const getPaymentRecipientWithBacs = (recipient_id, cb) => {
+        pCl.getPaymentRecipient(recipient_id,
+          (err, response) => {
+            expect(err).to.be(null);
+            expect(response).to.be.ok();
+            expect(response.request_id).to.be.ok();
+            expect(response.recipient_id).to.be.ok();
+            expect(response.name).to.be.ok();
+            expect(response.bacs).to.be.ok();
             expect(response.address).to.be.ok();
 
             cb(null, recipient_id);
@@ -1109,10 +1144,22 @@ describe('plaid.Client', () => {
         });
       };
 
-      it('successfully goes through the entire flow', cb => {
+      it('successfully goes through the entire flow with iban', cb => {
         async.waterfall([
-          createPaymentRecipient,
-          getPaymentRecipient,
+          createPaymentRecipientWithIban,
+          getPaymentRecipientWithIban,
+          listPaymentRecipients,
+          createPayment,
+          createPaymentToken,
+          getPayment,
+          listPayments,
+        ], cb);
+      });
+
+      it('successfully goes through the entire flow with bacs', cb => {
+        async.waterfall([
+          createPaymentRecipientWithBacs,
+          getPaymentRecipientWithBacs,
           listPaymentRecipients,
           createPayment,
           createPaymentToken,


### PR DESCRIPTION
The team recently updated the recipient create endpoint to take accept BACS instead of an iban. This PR updates the plaid-node library to allow developers to more easily supply BACS