### PR TITLE
fix: rename 'client_id' string to 'clientID'

### DIFF
--- a/lib/PlaidClient.js
+++ b/lib/PlaidClient.js
@@ -20,7 +20,7 @@ function Client(configs) {
   }
 
   if (R.isNil(configs.clientID)) {
-    throw new Error('Missing Plaid "client_id"');
+    throw new Error('Missing Plaid "clientID"');
   }
 
   if (R.isNil(configs.secret)) {

--- a/test/PlaidClientTest.js
+++ b/test/PlaidClientTest.js
@@ -33,7 +33,7 @@ describe('plaid.Client', () => {
   describe('constructor', () => {
     it('throws for invalid parameter', ()  => {
       expect(() => {
-        plaid.Client('client_id');
+        plaid.Client('clientID');
       }).to.throwException(e => {
         expect(e).to.be.ok();
         expect(e.message).to.equal(
@@ -44,14 +44,14 @@ describe('plaid.Client', () => {
       });
     });
 
-    it('throws for missing client_id', () => {
+    it('throws for missing clientID', () => {
       expect(() => {
         plaid.Client(R.merge(configs, {
           clientID: null,
         }));
       }).to.throwException(e => {
         expect(e).to.be.ok();
-        expect(e.message).to.equal('Missing Plaid "client_id"');
+        expect(e.message).to.equal('Missing Plaid "clientID"');
       });
     });
 


### PR DESCRIPTION
This is so that it is consistent with the field name that is
required in the constructor. Having them be inconsistent is very
confusing to a developer who is trying to make this new library
work.