### PR TITLE
Add registry and .npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+registry=https://registry.npmjs.com/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "plaid",
-  "version": "8.1.4",
+  "version": "8.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "plaid",
   "version": "8.2.0",
+  "registry": "https://registry.npmjs.com/",
   "description": "A node.js client for the Plaid API",
   "keywords": [
     "plaid",


### PR DESCRIPTION
This ensures `plaid-node` ignores any global `~/.npmrc` settings and uses the public npm registry.