### PR TITLE
Added subtype to investment transactions schema

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -325,6 +325,7 @@ declare module 'plaid' {
     price: number | null;
     fees: number | null;
     type: string | null;
+    subtype: string | null;
     iso_currency_code: string | null;
     unofficial_currency_code: string | null;
   }


### PR DESCRIPTION
## Description

* Added `subtype` to `InvestmentTransaction` schema response
* Note: without this addition, the `subtype` is still present in the `getInvestmentTransactions()` response