### PR TITLE
Added `createDepositSwitchAlt` function

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,8 @@ plaidClient.getLiabilities(access_token, cb);
 plaidClient.getDepositSwitch(deposit_switch_id, options, cb)
 // createDepositSwitch(String, String, Object?, Function)
 plaidClient.createDepositSwitch(target_account_id, target_access_token, options, cb);
+// createDepositSwitchAlt(Object, Object, Object?, Function)
+plaidClient.createDepositSwitchAlt(target_account, target_user, options, cb);
 // createDepositSwitchToken(String, Function)
 plaidClient.createDepositSwitchToken(deposit_switch_id, options, cb)
 

--- a/lib/PlaidClient.js
+++ b/lib/PlaidClient.js
@@ -541,6 +541,18 @@ Client.prototype.createDepositSwitch =
     }, options, cb);
   };
 
+// createDepositSwitchAlt(Object, Object, Object?, Function)
+Client.prototype.createDepositSwitchAlt =
+  function(target_account, target_user, options, cb) {
+    return this._authenticatedRequest({
+      path: '/deposit_switch/alt/create',
+      body: {
+        target_account: target_account,
+        target_user: target_user,
+      },
+    }, options, cb);
+  };
+
 // createDepositSwitchToken(String, Object?, Function)
 Client.prototype.createDepositSwitchToken =
   function(deposit_switch_id, options, cb) {

--- a/test/PlaidClientTest.js
+++ b/test/PlaidClientTest.js
@@ -1265,8 +1265,6 @@ describe('plaid.Client', () => {
             expect(err).to.be(null);
             expect(response).to.be.ok();
             expect(response.deposit_switch_id).to.be.ok();
-            expect(response.target_item_id).to.be.ok();
-            expect(response.target_account_id).to.be.ok();
             expect(response.date_created).to.be.ok();
             expect(response.state).to.be.ok();
             cb(null, deposit_switch_id);
@@ -1301,7 +1299,6 @@ describe('plaid.Client', () => {
         async.waterfall([
           createDepositSwitchAlt,
           getDepositSwitch,
-          createDepositSwitchToken,
         ], cb);
       });
     });

--- a/test/PlaidClientTest.js
+++ b/test/PlaidClientTest.js
@@ -1232,23 +1232,23 @@ describe('plaid.Client', () => {
       const createDepositSwitchAlt = (cb) => {
         pCl.createDepositSwitchAlt(
           {
-              account_number: '9900009606',
-              routing_number: '011401533',
-              account_name: 'Pilot Partner CHKG',
-              account_subtype: 'checking',
+            account_number: '9900009606',
+            routing_number: '011401533',
+            account_name: 'Pilot Partner CHKG',
+            account_subtype: 'checking',
           },
           {
-              given_name: 'Alberta',
-              family_name: 'Charleston',
-              phone: '14085551234',
-              address: {
-                  street: '1098 Harrison St',
-                  city: 'San Francisco',
-                  region: 'CA',
-                  postal_code: '94107',
-                  country: 'US'
-              },
-              email: 'alberta.charleston@example.com',
+            given_name: 'Alberta',
+            family_name: 'Charleston',
+            phone: '14085551234',
+            address: {
+              street: '1098 Harrison St',
+              city: 'San Francisco',
+              region: 'CA',
+              postal_code: '94107',
+              country: 'US'
+            },
+            email: 'alberta.charleston@example.com',
           },
           (err, response) => {
             expect(err).to.be(null);

--- a/test/PlaidClientTest.js
+++ b/test/PlaidClientTest.js
@@ -1229,6 +1229,35 @@ describe('plaid.Client', () => {
           });
       };
 
+      const createDepositSwitchAlt = (cb) => {
+        pCl.createDepositSwitchAlt(
+          {
+              account_number: '9900009606',
+              routing_number: '011401533',
+              account_name: 'Pilot Partner CHKG',
+              account_subtype: 'checking',
+          },
+          {
+              given_name: 'Alberta',
+              family_name: 'Charleston',
+              phone: '14085551234',
+              address: {
+                  street: '1098 Harrison St',
+                  city: 'San Francisco',
+                  region: 'CA',
+                  postal_code: '94107',
+                  country: 'US'
+              },
+              email: 'alberta.charleston@example.com',
+          },
+          (err, response) => {
+            expect(err).to.be(null);
+            expect(response).to.be.ok();
+            expect(response.deposit_switch_id).to.be.ok();
+            cb(null, response.deposit_switch_id);
+          });
+      };
+
       const getDepositSwitch = (deposit_switch_id, cb) => {
         pCl.getDepositSwitch(
           deposit_switch_id,
@@ -1263,6 +1292,14 @@ describe('plaid.Client', () => {
           getAccessToken,
           getAccountId,
           createDepositSwitch,
+          getDepositSwitch,
+          createDepositSwitchToken,
+        ], cb);
+      });
+
+      it('successfully goes through the entire deposit switch alt flow', cb => {
+        async.waterfall([
+          createDepositSwitchAlt,
           getDepositSwitch,
           createDepositSwitchToken,
         ], cb);

--- a/test/PlaidClientTest.js
+++ b/test/PlaidClientTest.js
@@ -1295,7 +1295,8 @@ describe('plaid.Client', () => {
         ], cb);
       });
 
-      it('successfully goes through the entire deposit switch alt flow', cb => {
+      it(`successfully goes through the 
+      entire deposit switch alt flow`, cb => {
         async.waterfall([
           createDepositSwitchAlt,
           getDepositSwitch,


### PR DESCRIPTION
# Description
* Added `.createDepositSwitchAlt()` making requests to `/deposit_switch/alt/create` endpoint to `lib/PlaidClient.js`
* Updated tests in `test/PlaidClientTest.js` to have to have tests for `createDepositSwitchAlt()` function
* Removed tests against response in `getDepositSwitch()` to account for some params not being there when it's Switch Alt
* Updated `README.md` to explain `createDepositSwitchAlt()`