### PR TITLE
Remove hardcoded release branch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ lint:
 
 .PHONY: release-major release-minor release-patch
 release-major release-minor release-patch:
-	@$(XYZ) --increment $(@:release-%=%) --branch release-8.1.0
+	@$(XYZ) --increment $(@:release-%=%)
 
 
 .PHONY: setup


### PR DESCRIPTION
Based on `xyz` documentation, this should cause master to be the default release branch