### PR TITLE
Support Get Paystubs

### DIFF
--- a/lib/PlaidClient.js
+++ b/lib/PlaidClient.js
@@ -316,6 +316,10 @@ Client.prototype.getHoldings =
 Client.prototype.getPaystub =
   requestWithIncomeVerificationId('/income/verification/paystub/get');
 
+// getPaystubs(String, Function)
+Client.prototype.getPaystubs =
+  requestWithIncomeVerificationId('/income/verification/paystubs/get');
+
 // getSummary(String, Function)
 Client.prototype.getSummary =
   requestWithIncomeVerificationId('/income/verification/summary/get');


### PR DESCRIPTION
# About

We're using the Plaid Income Verification product and the documentation (version 10) mentions there is an `income/verification/paystubs/get` API endpoint. This updates the Node Plaid client to support this call.

/cc @tylernappy who is working with me on our integration.