### PR TITLE
Support Income Verification Download Documents

### DIFF
--- a/lib/PlaidClient.js
+++ b/lib/PlaidClient.js
@@ -324,6 +324,10 @@ Client.prototype.getPaystubs =
 Client.prototype.getSummary =
   requestWithIncomeVerificationId('/income/verification/summary/get');
 
+// downloadDocuments(String, Function)
+Client.prototype.downloadDocuments =
+  requestWithIncomeVerificationId('/income/verification/documents/download');
+
 // getInvestmentTransactions(String, Date, Date, Object?, Function)
 Client.prototype.getInvestmentTransactions =
   function(access_token, start_date, end_date, options, cb) {

--- a/lib/PlaidClient.js
+++ b/lib/PlaidClient.js
@@ -61,14 +61,19 @@ var requestWithAccessToken = function(path) {
   };
 };
 
-var requestWithIncomeVerificationId = function(path) {
-  return function(incomeVerificationId, options, cb) {
-    return this._authenticatedRequest({
-      path: path,
-      body: {
-        income_verification_id: incomeVerificationId,
-      }
-    }, cb);
+var requestWithIncomeVerificationId = function (path, requestOptions = {}) {
+  console.table(requestOptions)
+  return function (incomeVerificationId, options, cb) {
+    return this._authenticatedRequest(
+      {
+        path: path,
+        body: {
+          income_verification_id: incomeVerificationId
+        },
+        binary: Boolean(requestOptions.binary)
+      },
+      cb
+    );
   };
 };
 
@@ -326,7 +331,7 @@ Client.prototype.getSummary =
 
 // downloadDocuments(String, Function)
 Client.prototype.downloadDocuments =
-  requestWithIncomeVerificationId('/income/verification/documents/download');
+  requestWithIncomeVerificationId('/income/verification/documents/download', { binary: true });
 
 // getInvestmentTransactions(String, Date, Date, Object?, Function)
 Client.prototype.getInvestmentTransactions =

--- a/lib/PlaidClient.js
+++ b/lib/PlaidClient.js
@@ -62,7 +62,6 @@ var requestWithAccessToken = function(path) {
 };
 
 var requestWithIncomeVerificationId = function (path, requestOptions = {}) {
-  console.table(requestOptions)
   return function (incomeVerificationId, options, cb) {
     return this._authenticatedRequest(
       {


### PR DESCRIPTION
# About

The Plaid Income Verification product supports an endpoint to download a zip of the files uploaded by a user. This PR adds a client call to invoke this endpoint. I've followed the convention of verb - model, in this case, `downloadDocuments` to compliment the `getSummary` and `getPaystub` calls. Happy to do whatever here.

> This endpoint provides the ability to download the source paystub PDFs that the
consumer uploaded via Paystub Import, as well as download the most recent source
paystub PDF as found on file at the payroll provider. This will either be the collection of
files that the consumer uploaded. If using Payroll Income, the most recent file available for
download with the payroll provider will be retrieved and available from this endpoint.
> POST /income/verification/documents/download

/cc @tylernappy 