### PR TITLE
include eu product initializer fields in create link token options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 ## 8.5.3
 - Extend `CreateLinkTokenOptions` interface with `institution_id` and `eu_config` to support initializing Modular and Headless link for EU products.
 
+## 8.5.2
+- Added additional EMI (E-Money Institution) support `options` to `/payment_initiation/payment/create`
+- Updated `/payment_initiation/payment/get`, `/payment_initiation/recipient/get`, and `/payment_initiation/recipient/list` to return additional EMI related fields
+
 ## 8.5.1
 - Upgrade package versions
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 8.5.3
+- Extend `CreateLinkTokenOptions` interface with `institution_id` and `eu_config` to support initializing Modular and Headless link for EU products.
+
 ## 8.5.1
 - Upgrade package versions
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 plaid-node  [![Circle CI](https://circleci.com/gh/plaid/plaid-node.svg?style=svg&circle-token=2efcf082d8df7e119325a4dbed9a1091ff5db422)](https://circleci.com/gh/plaid/plaid-node)  [![npm version](https://badge.fury.io/js/plaid.svg)](http://badge.fury.io/js/plaid)
 ==============
 
-:warning: After 7/12/21, this major version of the library will only receive critical security patches. Please consider trying out our new [beta version](https://github.com/plaid/plaid-node/tree/9.0.0-beta-release).
+:warning: After 8/16/21, this major version of the library will only receive critical security patches. Please consider trying out our new [beta version](https://github.com/plaid/plaid-node/tree/9.0.0-beta-release).
 
 A node.js client library for the [Plaid API][1].
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -90,6 +90,10 @@ declare module 'plaid' {
     payment_id: string;
   }
 
+  interface LinkTokenEUConfig {
+    headless?: boolean;
+  }
+
   interface DepositSwitchOptions {
     deposit_switch_id: string;
   }
@@ -114,6 +118,8 @@ declare module 'plaid' {
     payment_initiation?: PaymentInitiationOptions;
     deposit_switch?: DepositSwitchOptions;
     income_verification?: IncomeVerificationOptions;
+    institution_id?: string;
+    eu_config?: LinkTokenEUConfig;
   }
 
   // DATA TYPES //////////////////////////////////////////////////////////////

--- a/index.d.ts
+++ b/index.d.ts
@@ -122,6 +122,13 @@ declare module 'plaid' {
     eu_config?: LinkTokenEUConfig;
   }
 
+  interface PaymentCreateOptions {
+    bacs?: PaymentRecipientBacs;
+    emi_account_id?: string;
+    iban?: string;
+    request_refund_details?: boolean;
+  }
+
   // DATA TYPES //////////////////////////////////////////////////////////////
 
   interface AccountCommon {
@@ -550,6 +557,7 @@ declare module 'plaid' {
     name: string;
     iban: string;
     address: PaymentRecipientAddress;
+    emi_recipient_id: string;
   }
 
   interface PaymentAmount {
@@ -731,6 +739,7 @@ declare module 'plaid' {
     name: string;
     iban: string;
     address: PaymentRecipientAddress | null;
+    emi_recipient_id: string;
   }
 
   interface PaymentRecipientListResponse extends BaseResponse {
@@ -749,6 +758,7 @@ declare module 'plaid' {
     status: string;
     last_status_update: Iso8601DateTimeString;
     recipient_id: string;
+    emi_account_id: string;
   }
 
   interface PaymentTokenCreateResponse extends BaseResponse {
@@ -1102,17 +1112,25 @@ declare module 'plaid' {
 
     listPaymentRecipients(): Promise<PaymentRecipientListResponse>;
 
+    // createPayment(String, String, Object, Object?, Function)
+    createPayment(
+      recipient_id: string,
+      reference: string,
+      amount: PaymentAmount,
+      options: PaymentCreateOptions,
+      cb: Callback<PaymentCreateResponse>,
+    ): void;
     createPayment(
       recipient_id: string,
       reference: string,
       amount: PaymentAmount,
       cb: Callback<PaymentCreateResponse>,
     ): void;
-
     createPayment(
       recipient_id: string,
       reference: string,
       amount: PaymentAmount,
+      options?: PaymentCreateOptions,
     ): Promise<PaymentCreateResponse>;
 
     createPaymentToken(

--- a/lib/PlaidClient.js
+++ b/lib/PlaidClient.js
@@ -117,6 +117,8 @@ const linkTokenConfigFields = [
   'payment_initiation',
   'deposit_switch',
   'income_verification',
+  'institution_id',
+  'eu_config',
 ];
 
 // createLinkToken(CreateLinkTokenOptions, Function)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "plaid",
-  "version": "8.5.0",
+  "version": "8.5.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plaid",
-  "version": "8.5.1",
+  "version": "8.5.3",
   "description": "A node.js client for the Plaid API",
   "keywords": [
     "plaid",

--- a/test/PlaidClientTest.js
+++ b/test/PlaidClientTest.js
@@ -153,6 +153,33 @@ describe('plaid.Client', () => {
     });
   });
 
+  it('can create eu link tokens for modular link', cb => {
+    pCl.createLinkToken({
+      user: {
+        client_user_id: (new Date()).getTime().toString(),
+        legal_name: 'John Doe',
+        phone_number: '+1 415 555 0123',
+        phone_number_verified_time: '2020-01-01T00:00:00Z',
+        email_address: 'example@plaid.com',
+        email_address_verified_time: '2020-01-01T00:00:00Z'
+      },
+      client_name: 'Plaid App',
+      products: ['auth', 'transactions'],
+      country_codes: ['GB'],
+      language: 'en',
+      webhook: 'https://sample-web-hook.com',
+      institution_id: 'ins_116834',
+      eu_config: {
+        headless: true,
+      },
+    }, (err, successResponse) => {
+      expect(err).to.be(null);
+      expect(successResponse.link_token).to.match(/^link-sandbox-/);
+      expect(successResponse.expiration).to.be.ok();
+      cb();
+    });
+  });
+
   it('can get link tokens', cb => {
     pCl.createLinkToken({
       user: {

--- a/test/PlaidClientTest.js
+++ b/test/PlaidClientTest.js
@@ -1158,7 +1158,7 @@ describe('plaid.Client', () => {
           value: 100.00,
         };
         const options = {
-          emi_account_id: '123456789'
+          emi_account_id: 'sandbox-emi-account-id-123456789'
         };
 
         // This payment and recipient do not have an associated EMI account


### PR DESCRIPTION
This pull request is a patch intended to back port fields used to initialise the European link experiences (Modular link) into version 8 of the Plaid node client library. It does this by adding two fields to the `linkTokenConfigFields` allow list used to assemble the payload on `/link/token/create` as well as an update to the corresponding typescript definition for the `CreateLinkTokenOptions` interface. An additional test case was added using these fields, and ran using a valid client id and secret. 

Referencing the [NPM release history](https://www.npmjs.com/package/plaid), the patch version this change would introduced in looks to be 8.5.3. 

The pull request has been opened to master, although considering the intentions here, if this needs to be opened towards a dedicated release branch, please advise. 