### PR TITLE
include eu product initializer fields in create link token options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 8.5.3
+- Extend `CreateLinkTokenOptions` interface with `institution_id` and `eu_config` to support initializing Modular and Headless link for EU products.
+
 ## 8.5.2
 - Added additional EMI (E-Money Institution) support `options` to `/payment_initiation/payment/create`
 - Updated `/payment_initiation/payment/get`, `/payment_initiation/recipient/get`, and `/payment_initiation/recipient/list` to return additional EMI related fields

--- a/index.d.ts
+++ b/index.d.ts
@@ -90,6 +90,10 @@ declare module 'plaid' {
     payment_id: string;
   }
 
+  interface LinkTokenEUConfig {
+    headless?: boolean;
+  }
+
   interface DepositSwitchOptions {
     deposit_switch_id: string;
   }
@@ -114,6 +118,8 @@ declare module 'plaid' {
     payment_initiation?: PaymentInitiationOptions;
     deposit_switch?: DepositSwitchOptions;
     income_verification?: IncomeVerificationOptions;
+    institution_id?: string;
+    eu_config?: LinkTokenEUConfig;
   }
 
   interface PaymentCreateOptions {

--- a/lib/PlaidClient.js
+++ b/lib/PlaidClient.js
@@ -117,6 +117,8 @@ const linkTokenConfigFields = [
   'payment_initiation',
   'deposit_switch',
   'income_verification',
+  'institution_id',
+  'eu_config',
 ];
 
 // createLinkToken(CreateLinkTokenOptions, Function)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plaid",
-  "version": "8.5.2",
+  "version": "8.5.3",
   "description": "A node.js client for the Plaid API",
   "keywords": [
     "plaid",

--- a/test/PlaidClientTest.js
+++ b/test/PlaidClientTest.js
@@ -153,6 +153,33 @@ describe('plaid.Client', () => {
     });
   });
 
+  it('can create eu link tokens for modular link', cb => {
+    pCl.createLinkToken({
+      user: {
+        client_user_id: (new Date()).getTime().toString(),
+        legal_name: 'John Doe',
+        phone_number: '+1 415 555 0123',
+        phone_number_verified_time: '2020-01-01T00:00:00Z',
+        email_address: 'example@plaid.com',
+        email_address_verified_time: '2020-01-01T00:00:00Z'
+      },
+      client_name: 'Plaid App',
+      products: ['auth', 'transactions'],
+      country_codes: ['GB'],
+      language: 'en',
+      webhook: 'https://sample-web-hook.com',
+      institution_id: 'ins_116834',
+      eu_config: {
+        headless: true,
+      },
+    }, (err, successResponse) => {
+      expect(err).to.be(null);
+      expect(successResponse.link_token).to.match(/^link-sandbox-/);
+      expect(successResponse.expiration).to.be.ok();
+      cb();
+    });
+  });
+
   it('can get link tokens', cb => {
     pCl.createLinkToken({
       user: {
@@ -1130,9 +1157,12 @@ describe('plaid.Client', () => {
           currency: 'GBP',
           value: 100.00,
         };
+
         const options = {
-          emi_account_id: '123456789'
+          emi_account_id:
+          'emi-account-id-sandbox-1dc17e1f-aa82-4d79-9312-bef95797f8dc',
         };
+
 
         // This payment and recipient do not have an associated EMI account
         // so this request is expected to error.


### PR DESCRIPTION
This pull request is a patch intended to back port fields used to initialise the European link experiences (Modular link) into version 8 of the Plaid node client library. 

It does this by adding two fields to the `linkTokenConfigFields` allow list used to assemble the payload on `/link/token/create` as well as an update to the corresponding typescript definition for the `CreateLinkTokenOptions` interface. 

An additional test case was added using these fields, and ran using a valid client id and secret.

An existing test case for asserting correctness with EMI payments was updated to use correctly prefixed ids
